### PR TITLE
Fix two Compose-migration regressions: mesh re-centering and editor overflow

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/threejs/ThreeJsRenderer.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/threejs/ThreeJsRenderer.kt
@@ -159,15 +159,16 @@ class ThreeJsRenderer(private val canvasId: String) {
             if (disposed || loadedUrls[name] != url) return
 
             // 2. Yield so Compose/animation can paint a frame before the heavy
-            // synchronous geometry work begins (computeVertexNormals/center
-            // iterate every vertex and cannot be made non-blocking without a
-            // Web Worker, but yielding keeps the UI from pileup-freezing).
+            // synchronous geometry work begins (computeVertexNormals iterates
+            // every vertex and cannot be made non-blocking without a Web Worker,
+            // but yielding keeps the UI from pileup-freezing).
+            //
+            // Do NOT center() the geometry: each target is its own mesh, and
+            // re-centering every mesh to its own centroid discards the relative
+            // positions between targets. Konstructions rely on multiple elements
+            // appearing at their authored offsets.
             yield()
             geometry.computeVertexNormals()
-            if (disposed || loadedUrls[name] != url) return
-
-            yield()
-            geometry.center()
             if (disposed || loadedUrls[name] != url) return
 
             yield()

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/ContentPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/ContentPane.kt
@@ -25,8 +25,9 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -85,15 +86,22 @@ fun ContentPane(modifier: Modifier = Modifier) {
     val settingsVm = koinInject<SettingsViewModel>()
     val codePaneMode by settingsVm.codePaneMode.collectAsState()
 
-    Column(modifier = modifier) {
-        TopBar()
+    // Scaffold gives the content lambda a height bounded to "screen minus
+    // TopBar" (via innerPadding + bounded constraints). This is what lets
+    // child panes (and kodemirror) scroll within the viewport instead of
+    // overflowing it — a Column child would be measured with an unbounded
+    // vertical constraint, making fillMaxSize a no-op on the main axis.
+    Scaffold(
+        modifier = modifier,
+        topBar = { TopBar() }
+    ) { innerPadding ->
         AnimatedContent(
             targetState = codePaneMode,
             transitionSpec = {
                 val (enter, exit) = transitionSpec(initialState, targetState)
                 enter togetherWith exit
             },
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.padding(innerPadding).fillMaxSize()
         ) { mode ->
             when (mode) {
                 CodePaneMode.EDITOR -> EditorPane(modifier = Modifier.fillMaxSize())


### PR DESCRIPTION
## Summary
Two silent behavioral regressions introduced by the Kotlin/JS→WasmJS+Compose migration, both surfaced while building a multi-target model.

- **Stop re-centering each target mesh** (`ThreeJsRenderer`): the GL renderer called `geometry.center()` on every target as it loaded, snapping each to its own centroid and discarding the relative positions between targets. Multi-element konstructions couldn't be placed relative to each other and user translates were silently undone. Now renders at authored coordinates; the fixed camera + orbit controls handle framing.
- **Bound the editor below the TopBar via `Scaffold`** (`ContentPane`): the code pane was a `Column { TopBar(); AnimatedContent(Modifier.fillMaxSize()) }`. A non-weighted `Column` child gets an unbounded vertical constraint, so `fillMaxSize` was a no-op on the main axis — the editor grew to content height and overflowed the viewport (cursor off-screen at the bottom of long docs; kodemirror never scrolled). Replaced with `Scaffold(topBar = { TopBar() })`, whose content is bounded to "screen minus TopBar".

## Test plan
- [ ] Multi-target model (e.g. the kodee konstruction): body/visor/eyes render at correct relative positions.
- [ ] Long document: cursor at the bottom stays visible; editor scrolls within the pane.
- [ ] Other panes (navigation/settings/selection) still fill correctly; editor status footer stays pinned.

> Note: both changes are already deployed on adolin (out-of-process); this PR routes them through review retroactively.