### PR TITLE
Default editor theme to One Dark

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
@@ -76,7 +76,7 @@ class SettingsViewModel {
     val codePaneMode: StateFlow<CodePaneMode> = _codePaneMode.asStateFlow()
 
     private val editorThemeStore =
-        PersistedStateFlow.enum("editorTheme", EditorThemeName.DRACULA)
+        PersistedStateFlow.enum("editorTheme", EditorThemeName.ONE_DARK)
     private val keymapStore =
         PersistedStateFlow.enum("keymap", KeymapName.VIM)
     private val showCodeLeftStore =


### PR DESCRIPTION
## Summary
Change the unset default editor theme from Dracula to One Dark. `EditorThemeName.ONE_DARK` already exists as an option, so this is a one-line default change in `SettingsViewModel`. Users with a persisted `editorTheme` are unaffected.

Closes #5

## Test plan
- [ ] Fresh profile (cleared localStorage): editor opens in One Dark.
- [ ] Existing users with a saved theme are unchanged.