### PR TITLE
README: describe hauler as remote logging, not structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ runner all talk through one RPC layer.
 Konstructor is built on a stack of the author's own libraries:
 [**kcsg**](https://github.com/Monkopedia/KCSG) (geometry),
 [**ksrpc**](https://github.com/Monkopedia/ksrpc) (RPC over WebSockets),
-[**hauler**](https://github.com/Monkopedia/hauler) (structured logging), and
+[**hauler**](https://github.com/Monkopedia/hauler) (remote logging), and
 [**kodemirror**](https://github.com/Monkopedia/kodemirror) (a Compose Multiplatform CodeMirror
 wrapper that provides the script editor).
 


### PR DESCRIPTION
Hauler forwards logs across service boundaries over ksrpc (per its own README); "structured logging" was inaccurate. One-word fix to the tech-stack line. docs-only.