### PR TITLE
Fix stale render from previous workspace/konstruction shown after switch

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
@@ -104,6 +104,24 @@ class KonstructionViewModel(
             _state.value = UiState.LOADING
             _renderPath.value = null
             renderPaths.value = emptyMap()
+            // Drop any in-flight enable bookkeeping from the previous
+            // konstruction — keyed by target name on this singleton, a leftover
+            // entry could otherwise suppress a legitimate enable after switching.
+            inFlightEnables.clear()
+            // Unregister the previous konstruction's listener before wiring the
+            // new one, so a late callback from the de-selected konstruction can't
+            // keep mutating the now-shared flows. Capture the old refs first,
+            // clear them, then unregister.
+            val previousKs = konstructionService
+            val previousKey = listenerKey
+            konstructionService = null
+            listenerKey = null
+            if (previousKs != null && previousKey != null) {
+                try {
+                    previousKs.unregister(previousKey)
+                } catch (_: Exception) {
+                }
+            }
             targetDisplayRepo.activate(konstruction.workspaceId, konstruction.id)
             recomputeEnabledTargets()
             val service = serviceHolder.service.value
@@ -148,16 +166,20 @@ class KonstructionViewModel(
                             }
                         }.awaitAll()
                     }
-                    val newPaths = renderPaths.value.toMutableMap()
-                    for ((name, path) in paths) {
-                        if (path != null) {
-                            val fresh = freshen(path)
-                            newPaths[name] = fresh
-                            _renderPath.value = fresh
+                    // Re-check selection: a switch may have landed while the
+                    // konstructed() calls above were in flight.
+                    if (ks === konstructionService) {
+                        val newPaths = renderPaths.value.toMutableMap()
+                        for ((name, path) in paths) {
+                            if (path != null) {
+                                val fresh = freshen(path)
+                                newPaths[name] = fresh
+                                _renderPath.value = fresh
+                            }
                         }
+                        renderPaths.value = newPaths
+                        recomputeEnabledTargets()
                     }
-                    renderPaths.value = newPaths
-                    recomputeEnabledTargets()
                 } else {
                     autoCompileAndBuild(ks)
                 }
@@ -193,6 +215,8 @@ class KonstructionViewModel(
                     )
 
                 override suspend fun onInfoChanged(info: KonstructionInfo) {
+                    // Ignore late callbacks from a de-selected konstruction.
+                    if (ks !== konstructionService) return
                     _info.value = info
                     targetDisplayRepo.mergeTargets(info.targets.map { it.name })
                     when (info.dirtyState) {
@@ -227,16 +251,20 @@ class KonstructionViewModel(
                                     }
                                 }.awaitAll()
                             }
-                            val newPaths = renderPaths.value.toMutableMap()
-                            for ((name, path) in paths) {
-                                if (path != null) {
-                                    val fresh = freshen(path)
-                                    newPaths[name] = fresh
-                                    _renderPath.value = fresh
+                            // Re-check selection: a switch may have landed while
+                            // the konstructed() calls above were in flight.
+                            if (ks === konstructionService) {
+                                val newPaths = renderPaths.value.toMutableMap()
+                                for ((name, path) in paths) {
+                                    if (path != null) {
+                                        val fresh = freshen(path)
+                                        newPaths[name] = fresh
+                                        _renderPath.value = fresh
+                                    }
                                 }
+                                renderPaths.value = newPaths
+                                recomputeEnabledTargets()
                             }
-                            renderPaths.value = newPaths
-                            recomputeEnabledTargets()
                         }
 
                         else -> { /* other dirty states: no-op */ }
@@ -244,10 +272,12 @@ class KonstructionViewModel(
                 }
 
                 override suspend fun onDirtyStateChanged(state: DirtyState) {
+                    if (ks !== konstructionService) return
                     _info.value = _info.value?.copy(dirtyState = state)
                 }
 
                 override suspend fun onTargetChanged(target: KonstructionTarget) {
+                    if (ks !== konstructionService) return
                     val info = _info.value ?: return
                     val newTargets = info.targets.map {
                         if (it.name == target.name) target else it
@@ -256,6 +286,7 @@ class KonstructionViewModel(
                 }
 
                 override suspend fun onRenderChanged(render: KonstructionRender) {
+                    if (ks !== konstructionService) return
                     val path = render.renderPath
                     if (path != null) {
                         val fresh = freshen(path)
@@ -269,6 +300,7 @@ class KonstructionViewModel(
                 }
 
                 override suspend fun onContentChange(u: Unit) {
+                    if (ks !== konstructionService) return
                     try {
                         _content.value = ks.fetch()
                     } catch (_: Exception) {
@@ -276,6 +308,7 @@ class KonstructionViewModel(
                 }
 
                 override suspend fun onTaskComplete(taskResult: TaskResult) {
+                    if (ks !== konstructionService) return
                     _messages.value = taskResult.messages
                     _state.value = UiState.DEFAULT
                 }
@@ -387,6 +420,10 @@ class KonstructionViewModel(
                 } catch (_: Exception) {
                     null
                 }
+                // A switch may have landed while konstructed() was in flight;
+                // don't write the de-selected konstruction's render into the
+                // now-current view.
+                if (ks !== konstructionService) return@launch
                 if (existing != null) {
                     // Render already exists — surface it without rebuilding.
                     val fresh = freshen(existing)


### PR DESCRIPTION
## Summary
Fixes #12 — after switching workspace/konstruction, a 3D model from a different workspace would briefly flash into the new scene until a fresh render overwrote it.

## Root cause
`KonstructionViewModel` is a Koin singleton reused across every switch, so `onCleared()` — the only caller of `ks.unregister(...)` — never fires. `loadKonstruction` wired a new listener (`konstructionService = ks`, `listenerKey = ks.register(...)`) without unregistering the previous konstruction's, and the listener callbacks had no identity guard. A late callback from the de-selected konstruction (`onRenderChanged` / the `onInfoChanged`→CLEAN branch — captured `ks` is the old konstruction) wrote the old render URL into the shared `renderPaths`/`_renderPath`/`enabledRenderedTargets` flows, so the renderer showed the previous workspace's mesh until a fresh render landed.

## Fix (scoped to `KonstructionViewModel.kt`)
- **Unregister the previous listener before wiring the new one** in `loadKonstruction`: capture the old service/key, null them out, then `oldKs.unregister(oldKey)` (exception-guarded).
- **Clear `inFlightEnables` on switch** so a leftover target-name entry can't suppress a legitimate enable after switching.
- **Identity guards** `if (ks !== konstructionService) return` at the top of the mutating listener callbacks (`onInfoChanged`, `onDirtyStateChanged`, `onTargetChanged`, `onRenderChanged`, `onContentChange`, `onTaskComplete`).
- **Post-await re-checks**: the CLEAN paths (in `loadKonstruction` and `onInfoChanged`) and the `setTargetEnabled` coroutine re-verify `ks === konstructionService` after the suspending `konstructed()` calls before writing the shared flows, closing the switch-during-await window.

Normal (non-switch) behavior is preserved: the first load has no previous listener to unregister, and `ks === konstructionService` holds throughout.

## Verification
- Full e2e suite (`clean :e2e:test -Pe2e`, Mesa-EGL override under Xvfb): **BUILD SUCCESSFUL**, 39 tests, 0 failures, 0 errors (6 pre-existing skips). Includes `TargetControlTest` (3/3) and the navigation/workspace/konstruction-switch coverage.
- `:frontend:spotlessKotlinCheck`: passing (Apache header + ktlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)