### PR TITLE
Bump kodemirror 0.2.0 → 0.3.2 + enable editor soft-wrap

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
@@ -70,6 +70,7 @@ import com.monkopedia.kodemirror.themonedark.oneDark
 import com.monkopedia.kodemirror.view.KodeMirror
 import com.monkopedia.kodemirror.view.editorContentStyle
 import com.monkopedia.kodemirror.view.keymapOf
+import com.monkopedia.kodemirror.view.lineWrapping
 import com.monkopedia.kodemirror.view.onSave
 import com.monkopedia.kodemirror.view.saveKeymap
 import com.monkopedia.konstructor.common.KonstructionType
@@ -236,7 +237,7 @@ private fun EditorContent(
             config = LintConfig(delay = 0)
         )
         val extensions = basicSetup + themeExt + fontExt + kotlinLang +
-            keymapExt + saveKeymap + saveExt + lintExt + lintGutter()
+            keymapExt + saveKeymap + saveExt + lintExt + lintGutter() + lineWrapping
         val config = com.monkopedia.kodemirror.state.EditorStateConfig(
             doc = content.asDoc(),
             extensions = extensions

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ shadow = "8.3.6"
 javafx = "0.1.0"
 compose-multiplatform = "1.10.3"
 lifecycle = "2.10.0"
-kodemirror = "0.2.0"
+kodemirror = "0.3.2"
 spotless = "8.4.0"
 ktlint = "1.8.0"
 


### PR DESCRIPTION
## Summary
Resolves **#10** — long lines overflowed the editor (neither wrapped nor horizontally scrolled). Two changes in one file each:
- `gradle/libs.versions.toml`: `kodemirror = "0.2.0"` → `"0.3.2"`.
- `EditorPane.kt`: wire the opt-in `lineWrapping` extension into the editor so long lines **soft-wrap** to the editor width (the user's chosen behavior for #10).

## Why 0.3.2 (not 0.3.0/0.3.1)
0.3.0 introduced an editor-mount regression (kodemirror **#92**): `HoverTooltipPlugin` read the session `coroutineScope` before it was attached, crashing every editor mount that uses `linter` (we do, via lint's `hoverTooltip`). That failed 7 of our e2e tests. kodemirror shipped the fix in **0.3.2** (0.3.1 failed to publish). Transitively moves `com.monkopedia.lsp:lsp` RC → **1.0.0 stable**.

## Validation
- Full **clean `:e2e:test` green** on 0.3.2 — including the 7 editor-mount tests (Theme/Keymap, Target, Save) that failed on 0.3.0.
- `:frontend:spotlessKotlinCheck` clean.

Fixes #10