### PR TITLE
Vim display-line motion setting (j/k → gj/gk, vim-only)

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -176,6 +177,27 @@ private fun EditorContent(
     val settingsVm = koinInject<SettingsViewModel>()
     val themeName by settingsVm.editorTheme.collectAsState()
     val keymapName by settingsVm.keymap.collectAsState()
+    val vimDisplayLineMotion by settingsVm.vimDisplayLineMotion.collectAsState()
+
+    // The Vim mapping engine is a global singleton, so apply/restore the j/k →
+    // gj/gk remapping imperatively (rather than as an editor extension) and tie
+    // its lifetime to this effect. A null context covers normal + visual modes
+    // (insert is excluded by the engine), so vertical motion follows wrapped
+    // display lines. Cleanup runs when the keymap leaves Vim, the setting turns
+    // off, or the editor disposes — keeping it from leaking across switches.
+    DisposableEffect(keymapName, vimDisplayLineMotion) {
+        val mapped = keymapName == KeymapName.VIM && vimDisplayLineMotion
+        if (mapped) {
+            com.monkopedia.kodemirror.vim.Vim.map("j", "gj")
+            com.monkopedia.kodemirror.vim.Vim.map("k", "gk")
+        }
+        onDispose {
+            if (mapped) {
+                com.monkopedia.kodemirror.vim.Vim.unmap("j")
+                com.monkopedia.kodemirror.vim.Vim.unmap("k")
+            }
+        }
+    }
 
     val kotlinLang = remember { StreamLanguage.define(kotlin).extension }
 

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/settings/SettingsPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/settings/SettingsPane.kt
@@ -50,6 +50,7 @@ fun SettingsPane(modifier: Modifier = Modifier) {
     val showCameraWidget by settingsVm.showCameraWidget.collectAsState()
     val editorTheme by settingsVm.editorTheme.collectAsState()
     val keymap by settingsVm.keymap.collectAsState()
+    val vimDisplayLineMotion by settingsVm.vimDisplayLineMotion.collectAsState()
 
     Column(
         modifier = modifier.padding(16.dp),
@@ -79,6 +80,16 @@ fun SettingsPane(modifier: Modifier = Modifier) {
                 settingsVm.setKeymap(KeymapName.entries[index])
             }
         )
+
+        // Only meaningful for the Vim keymap, where it remaps j/k to gj/gk so
+        // vertical motion follows wrapped display lines instead of logical lines.
+        if (keymap == KeymapName.VIM) {
+            SettingSwitchRow(
+                label = "Vim display-line motion (j/k → gj/gk)",
+                checked = vimDisplayLineMotion,
+                onCheckedChange = { settingsVm.setVimDisplayLineMotion(it) }
+            )
+        }
 
         SettingSwitchRow(
             label = "Show code on left",

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
@@ -79,6 +79,8 @@ class SettingsViewModel {
         PersistedStateFlow.enum("editorTheme", EditorThemeName.ONE_DARK)
     private val keymapStore =
         PersistedStateFlow.enum("keymap", KeymapName.VIM)
+    private val vimDisplayLineMotionStore =
+        PersistedStateFlow.boolean("vimDisplayLineMotion", false)
     private val showCodeLeftStore =
         PersistedStateFlow.boolean("showCodeLeft", false)
     private val showFpsStore =
@@ -96,6 +98,7 @@ class SettingsViewModel {
 
     val editorTheme: StateFlow<EditorThemeName> = editorThemeStore.flow
     val keymap: StateFlow<KeymapName> = keymapStore.flow
+    val vimDisplayLineMotion: StateFlow<Boolean> = vimDisplayLineMotionStore.flow
     val showCodeLeft: StateFlow<Boolean> = showCodeLeftStore.flow
     val showFps: StateFlow<Boolean> = showFpsStore.flow
     val showCameraWidget: StateFlow<Boolean> = showCameraWidgetStore.flow
@@ -107,6 +110,7 @@ class SettingsViewModel {
     }
     fun setEditorTheme(theme: EditorThemeName) = editorThemeStore.set(theme)
     fun setKeymap(keymap: KeymapName) = keymapStore.set(keymap)
+    fun setVimDisplayLineMotion(value: Boolean) = vimDisplayLineMotionStore.set(value)
     fun setShowCodeLeft(value: Boolean) = showCodeLeftStore.set(value)
     fun setShowFps(value: Boolean) = showFpsStore.set(value)
     fun setShowCameraWidget(value: Boolean) = showCameraWidgetStore.set(value)


### PR DESCRIPTION
## Summary
Adds a persisted **Vim display-line motion** setting that remaps `j`→`gj` and `k`→`gk` when the Vim keymap is active, so vertical motion follows wrapped **display** lines rather than logical lines. Pairs with the editor soft-wrap enabled in #10. The toggle is **only shown when the keymap is Vim** — no visibility or effect for Default/Emacs.

## Changes (3 files, frontend only)
- **`SettingsViewModel.kt`** — new persisted `PersistedStateFlow.boolean("vimDisplayLineMotion", false)` with exposed flow + setter, mirroring the existing `keymap`/`showFps`/etc. settings.
- **`SettingsPane.kt`** — a `SettingSwitchRow` rendered only when `keymap == KeymapName.VIM`.
- **`EditorPane.kt`** — a `DisposableEffect` keyed on `(keymap, vimDisplayLineMotion)` that applies/removes the mapping imperatively.

## Vim mapping scope & cleanup
The kodemirror Vim engine (`Vim.map`/`Vim.unmap`, verified on 0.3.2) is a **global singleton** — mappings live in a shared keymap, not per-editor. So the mapping is applied imperatively from a `DisposableEffect` rather than as an editor extension:
- ON + Vim active → `Vim.map("j","gj")`, `Vim.map("k","gk")`.
- `onDispose` (which re-runs whenever the keys change) → `Vim.unmap("j")`, `Vim.unmap("k")`.

A **null mapping context** is used, which the engine applies in normal **and** visual modes (insert is excluded by the engine), matching the documented `Vim.map("j","gj")` idiom — so a single map covers both modes. Cleanup runs when the setting turns off, the keymap leaves Vim, or the editor disposes, so the global mapping never leaks across keymap switches or remounts.

## Verification
- Full e2e suite green locally (Mesa-EGL override): **39 tests, 0 failures, 0 errors** (6 skipped as usual). The keymap/settings tests (`ThemeAndKeymapTest` incl. `testKeymapSwitching`, `testSettingsPaneShowsDropdowns`) stay green with the new vim-gated toggle.
- `:frontend:spotlessKotlinCheck` passes; frontend WasmJS compiles clean (only pre-existing unrelated threejs opt-in warnings).

No e2e was added for the toggle: asserting it would require new TestBridge state/action plumbing (`JsBridge.kt`/`BridgeStateSnapshot.kt`), which is out of the issue's tight 3-file scope.

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)