### PR TITLE
Restore context-aware error footer (cursor-line error)

### DIFF
--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ErrorFooterTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ErrorFooterTest.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.e2e
+
+import com.microsoft.playwright.Page
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.Konstructor
+import com.monkopedia.konstructor.common.Space
+import com.monkopedia.ksrpc.ksrpcEnvironment
+import com.monkopedia.ksrpc.ktor.websocket.asWebsocketConnection
+import com.monkopedia.ksrpc.toStub
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.WebSockets
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+
+/**
+ * Reproduces and guards issue #33: the editor's error footer must be
+ * context-aware — show the compile error for the line the cursor is on, update
+ * as the cursor moves, and clear on a non-error line. Also verifies diagnostics
+ * land on the correct (header-offset-adjusted) user-content lines.
+ *
+ * The errored script has two unresolved references on known user-content lines:
+ *
+ * ```
+ * 1  val brokenCube by primitive {
+ * 2      cube {
+ * 3          dimensions = nonExistentSymbolXyz   // error here
+ * 4      }
+ * 5  }
+ * 6  val goodCube by primitive {
+ * 7      cube {
+ * 8          dimensions = alsoMissingSymbolAbc   // error here
+ * 9      }
+ * 10 }
+ * 11 export("brokenCube")
+ * ```
+ *
+ * The backend wraps user content in a fixed 3-line `.kt` header before compiling
+ * and subtracts that offset, so the diagnostics must report user lines 3 and 8.
+ */
+class ErrorFooterTest : BaseE2eTest() {
+
+    private val erroredScript = """
+        val brokenCube by primitive {
+            cube {
+                dimensions = nonExistentSymbolXyz
+            }
+        }
+        val goodCube by primitive {
+            cube {
+                dimensions = alsoMissingSymbolAbc
+            }
+        }
+        export("brokenCube")
+    """.trimIndent()
+
+    // The line numbers (1-based, in user content) where the two errors live.
+    private val errorLineA = 3
+    private val errorLineB = 8
+
+    private val parser = Json { ignoreUnknownKeys = true }
+
+    private fun setupWithErroredKonstruction() {
+        runBlocking {
+            val env = ksrpcEnvironment { }
+            val client = HttpClient { install(WebSockets) }
+            val conn = client.asWebsocketConnection("${server.baseUrl}/konstructor", env)
+            val service = conn.defaultChannel().toStub<Konstructor, String>()
+            val ws = service.create(Space(id = "", name = "ErrorFooterWs"))
+            val workspace = service.get(ws.id)
+            val kon = workspace.create(
+                Konstruction(name = "ErrorFooterKon", workspaceId = ws.id, id = "")
+            )
+            val ks = service.konstruction(kon)
+            ks.set(erroredScript)
+        }
+        loadApp()
+        waitForBridge()
+        page.reload()
+        waitForBridge()
+        page.waitForFunction(
+            "() => globalThis.__konstructor.state && " +
+                "globalThis.__konstructor.state.screen === 'main'",
+            null,
+            Page.WaitForFunctionOptions().setTimeout(60000.0)
+        )
+        bridgeAction("setCodePaneMode", "EDITOR")
+        // Wait for the auto compile to surface diagnostics in the bridge state.
+        page.waitForFunction(
+            "() => globalThis.__konstructor.state && " +
+                "globalThis.__konstructor.state.diagnostics && " +
+                "globalThis.__konstructor.state.diagnostics.length >= 2",
+            null,
+            Page.WaitForFunctionOptions().setTimeout(120000.0)
+        )
+    }
+
+    private fun diagnostics(): JsonArray {
+        val raw = page.evaluate(
+            "() => JSON.stringify(globalThis.__konstructor.state.diagnostics || [])"
+        ) as? String ?: "[]"
+        return parser.decodeFromString(JsonArray.serializer(), raw)
+    }
+
+    private fun diagnosticForLine(line: Int): JsonObject? =
+        diagnostics().map { it.jsonObject }.firstOrNull { it["line"]!!.jsonPrimitive.int == line }
+
+    private fun footerError(): String? {
+        val raw = page.evaluate(
+            "() => globalThis.__konstructor.state.footerError ?? null"
+        ) as? String
+        return raw
+    }
+
+    private fun cursorLine(): Int = (
+        page.evaluate("() => globalThis.__konstructor.state.cursorLine") as? Number
+        )?.toInt() ?: 0
+
+    private fun moveCursorToLine(line: Int) {
+        bridgeAction("moveCursorToLine", line.toString())
+        // Wait for the selection listener round-trip to land in the snapshot.
+        page.waitForFunction(
+            "(l) => globalThis.__konstructor.state.cursorLine === l",
+            line,
+            Page.WaitForFunctionOptions().setTimeout(10000.0)
+        )
+    }
+
+    /**
+     * Behavior 1: diagnostics highlight the right lines (header offset applied).
+     */
+    @Test
+    fun testDiagnosticsLandOnErrorLines() {
+        setupWithErroredKonstruction()
+
+        val diags = diagnostics()
+        assertTrue(diags.size >= 2, "Expected at least two diagnostics, got: $diags")
+
+        val diagA = diagnosticForLine(errorLineA)
+        val diagB = diagnosticForLine(errorLineB)
+        assertTrue(diagA != null, "Expected a diagnostic on line $errorLineA, got: $diags")
+        assertTrue(diagB != null, "Expected a diagnostic on line $errorLineB, got: $diags")
+        assertTrue(
+            diagA!!["message"]!!.jsonPrimitive.content.contains("nonExistentSymbolXyz"),
+            "Line $errorLineA diagnostic should mention the bad symbol: $diagA"
+        )
+        assertTrue(
+            diagB!!["message"]!!.jsonPrimitive.content.contains("alsoMissingSymbolAbc"),
+            "Line $errorLineB diagnostic should mention the bad symbol: $diagB"
+        )
+        // Every diagnostic must map inside the 11-line user content — a broken
+        // header offset would push lines past the document end.
+        for (d in diags) {
+            val line = d.jsonObject["line"]!!.jsonPrimitive.int
+            assertTrue(line in 1..11, "Diagnostic line $line out of user-content range: $d")
+        }
+    }
+
+    /**
+     * Behavior 2: cursor on an error line shows that line's error in the footer.
+     */
+    @Test
+    fun testCursorOnErrorLineShowsItsError() {
+        setupWithErroredKonstruction()
+
+        moveCursorToLine(errorLineA)
+        assertEquals(errorLineA, cursorLine())
+        val footer = footerError()
+        assertTrue(
+            footer != null && footer.contains("nonExistentSymbolXyz"),
+            "Footer should show the line-$errorLineA error, was: $footer"
+        )
+    }
+
+    /**
+     * Behavior 3: moving the cursor updates the footer — a different error line
+     * shows that error; a non-error line clears it.
+     */
+    @Test
+    fun testMovingCursorUpdatesFooter() {
+        setupWithErroredKonstruction()
+
+        // On the first error line.
+        moveCursorToLine(errorLineA)
+        assertTrue(
+            footerError()?.contains("nonExistentSymbolXyz") == true,
+            "Expected line-$errorLineA error, was: ${footerError()}"
+        )
+
+        // Onto the second error line — footer switches to that error.
+        moveCursorToLine(errorLineB)
+        val onB = footerError()
+        assertTrue(
+            onB?.contains("alsoMissingSymbolAbc") == true,
+            "Expected line-$errorLineB error, was: $onB"
+        )
+        assertTrue(
+            onB?.contains("nonExistentSymbolXyz") != true,
+            "Footer should no longer show the line-$errorLineA error, was: $onB"
+        )
+
+        // Onto a non-error line (line 1) — footer clears.
+        moveCursorToLine(1)
+        assertNull(footerError(), "Footer should clear on a non-error line")
+    }
+}

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/BridgeStateSnapshot.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/BridgeStateSnapshot.kt
@@ -28,6 +28,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TargetSnapshot(val name: String, val color: String, val isEnabled: Boolean)
 
+/**
+ * A single compiler diagnostic surfaced in the editor, as the e2e tests see it:
+ * the 1-based user-content [line] (already offset back past the wrapped `.kt`
+ * header), the [message] text, and the [importance] (ERROR/WARNING/INFO).
+ */
+@Serializable
+data class DiagnosticSnapshot(val line: Int, val message: String, val importance: String)
+
 @Serializable
 data class AppStateSnapshot(
     val ready: Boolean = false,
@@ -42,5 +50,11 @@ data class AppStateSnapshot(
     val screen: String = "loading",
     val konstructionCount: Int = 0,
     val konstructionNames: List<String> = emptyList(),
-    val targets: List<TargetSnapshot> = emptyList()
+    val targets: List<TargetSnapshot> = emptyList(),
+    // Editor error-footer surface (issue #33): the current diagnostics, the
+    // editor's 1-based cursor line, and the footer text the editor shows for the
+    // cursor's line (null when the cursor is not on a line with a message).
+    val diagnostics: List<DiagnosticSnapshot> = emptyList(),
+    val cursorLine: Int = 0,
+    val footerError: String? = null
 )

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
@@ -303,6 +303,18 @@ object JsBridge {
                 }
             }
         }
+        // Move the editor cursor to a 1-based line (issue #33). The editor draws
+        // to a canvas with no DOM, so the e2e harness drives cursor moves through
+        // this action rather than Playwright clicks. The selection listener then
+        // updates cursorLine/footerError, which feeds back into the snapshot.
+        exposeAction("moveCursorToLine") { lineStr ->
+            try {
+                konstructionVm?.moveCursorToLine(lineStr.trim().toInt())
+                incrementVersion()
+            } catch (e: Exception) {
+                setError("moveCursorToLine failed: ${e.message}")
+            }
+        }
 
         val refreshTrigger = kotlinx.coroutines.flow.MutableStateFlow(0)
         refreshTriggerRef = refreshTrigger
@@ -321,6 +333,17 @@ object JsBridge {
         if (konstructionVm != null) {
             scope.launch {
                 konstructionVm.targetDisplays.collect { refreshTrigger.value++ }
+            }
+            // Re-snapshot when diagnostics or the cursor's active error change so
+            // the error-footer surface (issue #33) stays current for e2e reads.
+            scope.launch {
+                konstructionVm.messages.collect { refreshTrigger.value++ }
+            }
+            scope.launch {
+                konstructionVm.cursorLine.collect { refreshTrigger.value++ }
+            }
+            scope.launch {
+                konstructionVm.activeMessage.collect { refreshTrigger.value++ }
             }
         }
 
@@ -395,6 +418,15 @@ object JsBridge {
                 isEnabled = display.isEnabled
             )
         } ?: emptyList()
+        val diagnostics = konstructionVm?.messages?.value
+            ?.mapNotNull { msg ->
+                val line = msg.line ?: return@mapNotNull null
+                DiagnosticSnapshot(
+                    line = line,
+                    message = msg.message,
+                    importance = msg.importance.name
+                )
+            } ?: emptyList()
         return AppStateSnapshot(
             ready = true,
             connected = connected,
@@ -412,7 +444,10 @@ object JsBridge {
             },
             konstructionCount = konNames.size,
             konstructionNames = konNames,
-            targets = targets
+            targets = targets,
+            diagnostics = diagnostics,
+            cursorLine = konstructionVm?.cursorLine?.value ?: 0,
+            footerError = konstructionVm?.activeMessage?.value?.message
         )
     }
 

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
@@ -47,6 +47,7 @@ import com.monkopedia.kodemirror.lint.lintGutter
 import com.monkopedia.kodemirror.lint.linter
 import com.monkopedia.kodemirror.materialtheme.rememberMaterialEditorTheme
 import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.LineNumber
 import com.monkopedia.kodemirror.state.asDoc
 import com.monkopedia.kodemirror.state.asInsert
 import com.monkopedia.kodemirror.state.extensionListOf
@@ -74,6 +75,7 @@ import com.monkopedia.kodemirror.view.keymapOf
 import com.monkopedia.kodemirror.view.lineWrapping
 import com.monkopedia.kodemirror.view.onSave
 import com.monkopedia.kodemirror.view.saveKeymap
+import com.monkopedia.kodemirror.view.select
 import com.monkopedia.konstructor.common.KonstructionType
 import com.monkopedia.konstructor.frontend.viewmodel.EditorThemeName
 import com.monkopedia.konstructor.frontend.viewmodel.KeymapName
@@ -95,6 +97,7 @@ fun EditorPane(modifier: Modifier = Modifier) {
     val content by konstructionVm.content.collectAsState()
     val uiState by konstructionVm.state.collectAsState()
     val messages by konstructionVm.messages.collectAsState()
+    val activeMessage by konstructionVm.activeMessage.collectAsState()
 
     // Load konstruction content when selection changes
     LaunchedEffect(selectedKonId, konstructions) {
@@ -154,8 +157,18 @@ fun EditorPane(modifier: Modifier = Modifier) {
             UiState.EXECUTING -> StatusBar("Executing...", Color(0xFFFFB74D), statusModifier)
 
             UiState.DEFAULT -> {
-                if (messages.isNotEmpty()) {
-                    StatusBar(
+                // Context-aware footer (restores pre-migration behavior): when the
+                // cursor sits on a line that has a compiler message, show that
+                // message's text; otherwise fall back to the message count.
+                val active = activeMessage
+                when {
+                    active != null -> StatusBar(
+                        active.message,
+                        Color(0xFFEF5350),
+                        statusModifier
+                    )
+
+                    messages.isNotEmpty() -> StatusBar(
                         "${messages.size} message(s)",
                         Color(0xFFEF5350),
                         statusModifier
@@ -264,9 +277,32 @@ private fun EditorContent(
             doc = content.asDoc(),
             extensions = extensions
         )
+        // Report the primary cursor's 1-based line to the view model on every
+        // transaction (cursor move, edit, etc.). The view model maps that line
+        // onto the diagnostics to drive the context-aware footer, restoring the
+        // pre-migration cursor-line error. We use the session's onUpdate callback
+        // (fired for every dispatched transaction) and read the resulting state's
+        // selection head, resolving it to a line via the document.
         com.monkopedia.kodemirror.view.EditorSession(
             com.monkopedia.kodemirror.state.EditorState.create(config)
-        )
+        ) { tr ->
+            val state = tr.state
+            val line = state.doc.lineAt(state.selection.main.head).number.value
+            konstructionVm.updateCursorLine(line)
+        }
+    }
+
+    // Register a cursor mover so external callers (the e2e bridge) can drive the
+    // cursor to a 1-based line deterministically — the editor renders to a canvas
+    // with no DOM for Playwright to click. Cleared when the session is replaced.
+    DisposableEffect(session, konstructionVm) {
+        konstructionVm.setCursorMover { line ->
+            val doc = session.state.doc
+            val clamped = line.coerceIn(1, doc.lines)
+            val pos = doc.line(LineNumber(clamped)).from
+            session.select(pos)
+        }
+        onDispose { konstructionVm.setCursorMover(null) }
     }
 
     // Push compiler messages into the editor as diagnostics. Diagnostics are

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
@@ -33,8 +33,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 enum class UiState {
@@ -61,6 +64,44 @@ class KonstructionViewModel(
 
     private val _messages = MutableStateFlow<List<TaskMessage>>(emptyList())
     val messages: StateFlow<List<TaskMessage>> = _messages.asStateFlow()
+
+    // The editor's current primary-cursor line (1-based; 0 = unknown / no
+    // cursor yet). Pushed in from the EditorPane's selection listener so the
+    // context-aware footer (and the e2e bridge) can map the cursor onto the
+    // diagnostic, if any, covering that line.
+    private val _cursorLine = MutableStateFlow(0)
+    val cursorLine: StateFlow<Int> = _cursorLine.asStateFlow()
+
+    /**
+     * The compiler message whose [TaskMessage.line] matches the current cursor
+     * line, or null when the cursor is not on a line that has a message. This is
+     * the text the editor footer surfaces — restoring the pre-migration
+     * cursor-line error behavior. Recomputed whenever messages or the cursor
+     * move.
+     */
+    val activeMessage: StateFlow<TaskMessage?> =
+        combine(_messages, _cursorLine) { messages, line ->
+            if (line < 1) null else messages.firstOrNull { it.line == line }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    // Set by the EditorPane once a session exists so external callers (the e2e
+    // bridge) can drive the cursor to a given 1-based line deterministically.
+    private var cursorMover: ((Int) -> Unit)? = null
+
+    /** Register the callback the editor uses to move its cursor to a line. */
+    fun setCursorMover(mover: ((Int) -> Unit)?) {
+        cursorMover = mover
+    }
+
+    /** Report the editor's current 1-based primary-cursor line. */
+    fun updateCursorLine(line: Int) {
+        _cursorLine.value = line
+    }
+
+    /** Drive the editor cursor to [line] (1-based), if a mover is registered. */
+    fun moveCursorToLine(line: Int) {
+        cursorMover?.invoke(line)
+    }
 
     private val _renderPath = MutableStateFlow<String?>(null)
     val renderPath: StateFlow<String?> = _renderPath.asStateFlow()
@@ -103,6 +144,7 @@ class KonstructionViewModel(
         viewModelScope.launch {
             _state.value = UiState.LOADING
             _renderPath.value = null
+            _cursorLine.value = 0
             renderPaths.value = emptyMap()
             // Drop any in-flight enable bookkeeping from the previous
             // konstruction — keyed by target name on this singleton, a leftover


### PR DESCRIPTION
## Summary
Fixes **#33** — a Compose-migration regression. Pre-migration, putting the cursor on a line with a compile error showed *that* error in the bottom footer; moving on/off lines updated it. That regressed: the footer only showed a generic `"N message(s)"` count and the editor never tracked cursor position. Error squiggles/gutter still worked — only the cursor→footer link was lost.

## Fix
Wire the kodemirror session's `onUpdate` callback (fired on every dispatched transaction) to report the primary cursor's 1-based line to the view model. (The `updateListener` facet looked like the natural hook but is never dispatched in kodemirror 0.3.2, so `onUpdate` is the working path.) The view model maps that line onto the current diagnostics, and the footer shows the matching error (falling back to the count when the cursor isn't on an error line). Lint squiggles/gutter unchanged.

## Tests (TDD — reproduced the regression first)
New `ErrorFooterTest` (e2e) asserts the three behaviors from #33:
1. diagnostics land on the right lines,
2. cursor on an error line shows its error in the footer,
3. moving the cursor updates/clears the footer.

**Before the fix**, (2) and (3) FAILED (Playwright timeouts), while (1) passed — i.e. the diagnostic line-offset was already correct; only the cursor→footer link regressed:
```
ErrorFooterTest > testCursorOnErrorLineShowsItsError FAILED
    com.microsoft.playwright.TimeoutError at ErrorFooterTest.kt:146
ErrorFooterTest > testMovingCursorUpdatesFooter FAILED
    com.microsoft.playwright.TimeoutError at ErrorFooterTest.kt:146
3 tests completed, 2 failed
```
Required new **TestBridge hooks** (error lines, cursor line, footer text + a deterministic cursor-mover action), since the bridge exposed none of that.

## Validation
- Full clean `:e2e:test` green incl. `ErrorFooterTest`; existing suite stays green. `:frontend:spotlessKotlinCheck` clean.

## Review note
@Monkopedia — touches editor UX (the restored footer behavior); please eyeball the final footer. Relates to #32 (broader error-surfacing UX).

Fixes #33
