### PR TITLE
LSP Phase 1: flag-gated ksrpc transport pipe (stub server)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -47,6 +47,8 @@ kotlin {
         implementation(libs.kotlinx.serialization.cbor)
         implementation(project(":protocol"))
         implementation(project(":lib"))
+        // DefaultLanguageServer + LSP types for the stub LSP server.
+        implementation(libs.lsp.ksrpc)
         implementation(libs.clikt)
         implementation(libs.ktor.server.core)
         implementation(libs.ktor.server.compression)

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -40,6 +40,9 @@ import com.monkopedia.konstructor.common.TaskStatus.SUCCESS
 import com.monkopedia.konstructor.logging.LoggingService
 import com.monkopedia.konstructor.logging.WarehouseWrapper
 import com.monkopedia.konstructor.logging.callContext
+import com.monkopedia.konstructor.lsp.StubLanguageServer
+import com.monkopedia.lsp.KsrpcLanguageClient
+import com.monkopedia.lsp.KsrpcLanguageServer
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -80,6 +83,16 @@ class KonstructionServiceImpl(
             info.name
         )
     }
+
+    override suspend fun lsp(client: KsrpcLanguageClient): KsrpcLanguageServer =
+        callContext("lsp", baseCallSign = konstructionController.callSign) {
+            // Phase 1: hand back a stub server that holds onto the editor's
+            // client (passed as a ksrpc param, so its publishDiagnostics channel
+            // is multiplexed onto the same WebSocket) and pushes one canned
+            // diagnostic on didOpen. The real Kotlin engine lands in epic #35
+            // Phase 2.
+            StubLanguageServer(client)
+        }
 
     override suspend fun close() =
         callContext("close", baseCallSign = konstructionController.callSign) {

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/StubLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/StubLanguageServer.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.lsp
+
+import com.monkopedia.lsp.BooleanOr
+import com.monkopedia.lsp.CompletionOptions
+import com.monkopedia.lsp.DefaultLanguageServer
+import com.monkopedia.lsp.Diagnostic
+import com.monkopedia.lsp.DiagnosticSeverity
+import com.monkopedia.lsp.DidOpenTextDocumentParams
+import com.monkopedia.lsp.InitializeParams
+import com.monkopedia.lsp.InitializeResult
+import com.monkopedia.lsp.InitializeResultServerInfo
+import com.monkopedia.lsp.KsrpcLanguageClient
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.PublishDiagnosticsParams
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.ServerCapabilities
+
+/**
+ * Phase 1 **stub** LSP server (no real Kotlin engine yet).
+ *
+ * It exists only to prove the ksrpc LSP transport pipe end-to-end:
+ *  - [initialize] returns a canned [InitializeResult] advertising hover +
+ *    completion support, so the editor's [LSPClient] handshake succeeds.
+ *  - on [textDocumentDidOpen] it pushes exactly one canned
+ *    `publishDiagnostics` (a single fake warning on line 0) back to the editor
+ *    through the [client] handed to it in `KonstructionService.lsp(client)`.
+ *
+ * The real engine integration lands in epic #35 Phase 2; this class is the
+ * minimal server that lets the round-trip be observed/asserted.
+ */
+class StubLanguageServer(private val client: KsrpcLanguageClient) : DefaultLanguageServer() {
+
+    override suspend fun initialize(params: InitializeParams): InitializeResult = InitializeResult(
+        capabilities = ServerCapabilities(
+            completionProvider = CompletionOptions(),
+            hoverProvider = BooleanOr(true)
+        ),
+        serverInfo = InitializeResultServerInfo(
+            name = "konstructor-lsp-stub",
+            version = "1"
+        )
+    )
+
+    override suspend fun textDocumentDidOpen(params: DidOpenTextDocumentParams) {
+        // Push a single canned diagnostic back to the editor over the reverse
+        // (server→client) channel multiplexed onto the same WebSocket. This is
+        // the round-trip the flag-gated Phase 1 wiring proves.
+        val uri = params.textDocument.uri
+        client.textDocumentPublishDiagnostics(
+            PublishDiagnosticsParams(
+                uri = uri,
+                diagnostics = listOf(
+                    Diagnostic(
+                        range = Range(
+                            start = Position(line = 0u, character = 0u),
+                            end = Position(line = 0u, character = 1u)
+                        ),
+                        severity = DiagnosticSeverity.WARNING,
+                        source = SOURCE,
+                        message = CANNED_MESSAGE
+                    )
+                )
+            )
+        )
+    }
+
+    companion object {
+        /** Source label on the canned diagnostic — also the e2e assertion hook. */
+        const val SOURCE = "konstructor-lsp-stub"
+
+        /** The canned warning message pushed on didOpen. */
+        const val CANNED_MESSAGE = "LSP stub: transport pipe is connected."
+    }
+}

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/LspPipeTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/LspPipeTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.e2e
+
+import com.microsoft.playwright.Page
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.Konstructor
+import com.monkopedia.ksrpc.ksrpcEnvironment
+import com.monkopedia.ksrpc.ktor.websocket.asWebsocketConnection
+import com.monkopedia.ksrpc.toStub
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.WebSockets
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+/**
+ * Phase 1 LSP transport pipe (epic #35 / issue #36).
+ *
+ * Proves the flag-ON round-trip: with the `lspEnabled` flag on, opening a
+ * konstruction in the editor opens the nested ksrpc LSP sub-service, the backend
+ * stub server pushes one canned `publishDiagnostics` back over the reverse
+ * channel, and the editor's client records it on the JS bridge
+ * (`globalThis.__konstructor.lspDiagnostics`).
+ *
+ * The flag-OFF behavior (editor byte-for-byte unchanged) is covered by the rest
+ * of the suite running with the default-off flag.
+ */
+class LspPipeTest : BaseE2eTest() {
+
+    private val validScript = """
+        val simpleCube by primitive {
+            cube {
+                dimensions = xyz(10.0, 10.0, 10.0)
+            }
+        }
+        export("simpleCube")
+    """.trimIndent()
+
+    @Test
+    fun testCannedDiagnosticRoundTripsWhenFlagOn() {
+        loadApp()
+        waitForBridge()
+
+        bridgeAction("createWorkspace", "LspWs")
+        val wsId = bridgeStateStringList("workspaceIds").first()
+
+        // Create a konstruction with valid content via the API up-front, so the
+        // single reload below lands on a workspace that already has it.
+        val konId = runBlocking {
+            val env = ksrpcEnvironment { }
+            val client = HttpClient { install(WebSockets) }
+            val conn = client.asWebsocketConnection("${server.baseUrl}/konstructor", env)
+            val service = conn.defaultChannel().toStub<Konstructor, String>()
+            val workspace = service.get(wsId)
+            val kon = workspace.create(
+                Konstruction(name = "LspTest", workspaceId = wsId, id = "")
+            )
+            service.konstruction(kon).set(validScript)
+            kon.id
+        }
+
+        // Reload so Initializer auto-selects the workspace + konstruction.
+        page.reload()
+        waitForBridge()
+        waitForMainScreen()
+
+        // Open the editor and select the konstruction so its editor pane mounts.
+        bridgeAction("setCodePaneMode", "EDITOR")
+        bridgeActionNoWait("selectKonstruction", konId)
+
+        // Turn the LSP flag ON: the editor (re)builds the LSP session, which
+        // sends didOpen and triggers the backend stub's canned publishDiagnostics.
+        bridgeAction("setLspEnabled", "true")
+
+        // Wait for the canned diagnostic to round-trip back to the editor client.
+        page.waitForFunction(
+            "() => globalThis.__konstructor.lspDiagnostics && " +
+                "globalThis.__konstructor.lspDiagnostics.count >= 1",
+            null,
+            Page.WaitForFunctionOptions().setTimeout(60000.0)
+        )
+
+        val count = (
+            page.evaluate("() => globalThis.__konstructor.lspDiagnostics.count") as? Number
+            )?.toInt() ?: 0
+        val uri = page.evaluate("() => globalThis.__konstructor.lspDiagnostics.uri")?.toString()
+        System.err.println("LSP diagnostics received: count=$count uri=$uri")
+        assert(count >= 1) { "Expected the canned LSP diagnostic to round-trip, got count=$count" }
+    }
+
+    private fun waitForMainScreen() {
+        page.waitForFunction(
+            "() => globalThis.__konstructor.state && " +
+                "globalThis.__konstructor.state.screen === 'main'",
+            null,
+            Page.WaitForFunctionOptions().setTimeout(60000.0)
+        )
+    }
+}

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -82,6 +82,14 @@ kotlin {
         implementation("com.monkopedia.kodemirror:language")
         implementation("com.monkopedia.kodemirror:lezer-highlight")
         implementation("com.monkopedia.kodemirror:lint")
+        // LSP editor support (transport-agnostic LSPClient / languageServerSupport).
+        // Not BOM-managed, so pin the version explicitly like vim.
+        implementation("com.monkopedia.kodemirror:lsp-client:${libs.versions.kodemirror.get()}")
+
+        // LSP ksrpc service interfaces (KsrpcLanguageServer / KsrpcLanguageClient,
+        // DefaultLanguageClient) for the wasmJs editor side. lsp-ksrpc is api in
+        // :protocol, but declare it explicitly since the editor references it.
+        implementation(libs.lsp.ksrpc)
 
         // Network / RPC
         implementation(libs.ksrpc.ktor.client)

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
@@ -95,6 +95,10 @@ object JsBridge {
             )
             incrementVersion()
         }
+        exposeAction("setLspEnabled") { enabled ->
+            settingsVm.setLspEnabled(enabled.toBoolean())
+            incrementVersion()
+        }
         exposeAction("setTargetEnabled") { argJson ->
             try {
                 val args = json.decodeFromString<JsonObject>(argJson)
@@ -478,6 +482,24 @@ private external fun setError(error: String)
 
 @JsFun("(s) => { globalThis.__konstructor.lastResult = JSON.parse(s); }")
 private external fun setLastResult(resultJson: String)
+
+/**
+ * Record the most recent LSP `publishDiagnostics` round-trip on the JS bridge so
+ * Playwright e2e tests can assert the flag-ON LSP pipe delivered diagnostics
+ * from the backend to the editor. No-op effect on the editor itself — this is
+ * purely an observation hook (see EditorPane's LSP wiring).
+ */
+fun reportLspDiagnostics(uri: String, count: Int) {
+    setLspDiagnostics(uri, count)
+    incrementVersion()
+}
+
+@JsFun(
+    "(uri, count) => { " +
+        "globalThis.__konstructor.lspDiagnostics = { uri: uri, count: count }; " +
+        "}"
+)
+private external fun setLspDiagnostics(uri: String, count: Int)
 
 private fun exposeAction(name: String, action: (String) -> Unit) {
     exposeActionJs(name, action)

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorLspClient.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorLspClient.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.frontend.ui.editor
+
+import com.monkopedia.lsp.DefaultLanguageClient
+import com.monkopedia.lsp.LanguageClient
+import com.monkopedia.lsp.PublishDiagnosticsParams
+
+/**
+ * The editor's server→client endpoint, passed as the param to
+ * `KonstructionService.lsp(client)`. ksrpc multiplexes its reverse channel onto
+ * the same WebSocket, so the backend can push notifications (most importantly
+ * `textDocument/publishDiagnostics`) back here without a second connection.
+ *
+ * It forwards every server-pushed diagnostic to kodemirror's own
+ * [LanguageClient] (`LSPClient.languageClient`), which resolves the file/session
+ * and renders the diagnostics into the editor's `:lint` layer. It additionally
+ * invokes [onDiagnostics] so callers (e.g. the e2e test bridge) can observe the
+ * round-trip having completed.
+ *
+ * Late binding: this client must be passed to `lsp(client)` to obtain the
+ * server, but kodemirror's routing [LanguageClient] only exists once the
+ * resulting [com.monkopedia.kodemirror.lsp.LSPClient] is constructed from that
+ * server. So [editorClient] is wired in after construction via [bind]. Until it
+ * is bound, diagnostics are still reported to [onDiagnostics] but not routed to
+ * the editor.
+ *
+ * @param onDiagnostics observation hook fired on every push, for e2e/testing.
+ */
+class EditorLspClient(private val onDiagnostics: (PublishDiagnosticsParams) -> Unit = {}) :
+    DefaultLanguageClient() {
+
+    private var editorClient: LanguageClient? = null
+
+    /** Bind kodemirror's routing client once the LSPClient has been built. */
+    fun bind(editorClient: LanguageClient) {
+        this.editorClient = editorClient
+    }
+
+    override suspend fun textDocumentPublishDiagnostics(params: PublishDiagnosticsParams) {
+        // Route into kodemirror's editor diagnostics (:lint) ...
+        editorClient?.textDocumentPublishDiagnostics(params)
+        // ... then notify observers (e2e bridge) that diagnostics arrived.
+        onDiagnostics(params)
+    }
+}

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
@@ -28,8 +28,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,6 +47,9 @@ import com.monkopedia.kodemirror.lint.LintConfig
 import com.monkopedia.kodemirror.lint.forceLinting
 import com.monkopedia.kodemirror.lint.lintGutter
 import com.monkopedia.kodemirror.lint.linter
+import com.monkopedia.kodemirror.lsp.LSPClient
+import com.monkopedia.kodemirror.lsp.LSPClientConfig
+import com.monkopedia.kodemirror.lsp.languageServerSupport
 import com.monkopedia.kodemirror.materialtheme.rememberMaterialEditorTheme
 import com.monkopedia.kodemirror.state.Extension
 import com.monkopedia.kodemirror.state.asDoc
@@ -75,6 +80,7 @@ import com.monkopedia.kodemirror.view.lineWrapping
 import com.monkopedia.kodemirror.view.onSave
 import com.monkopedia.kodemirror.view.saveKeymap
 import com.monkopedia.konstructor.common.KonstructionType
+import com.monkopedia.konstructor.frontend.reportLspDiagnostics
 import com.monkopedia.konstructor.frontend.viewmodel.EditorThemeName
 import com.monkopedia.konstructor.frontend.viewmodel.KeymapName
 import com.monkopedia.konstructor.frontend.viewmodel.KonstructionViewModel
@@ -178,6 +184,47 @@ private fun EditorContent(
     val themeName by settingsVm.editorTheme.collectAsState()
     val keymapName by settingsVm.keymap.collectAsState()
     val vimDisplayLineMotion by settingsVm.vimDisplayLineMotion.collectAsState()
+    val lspEnabled by settingsVm.lspEnabled.collectAsState()
+    // Reactive so the LSP session is (re)built once the konstruction's service
+    // finishes loading, not just when selection changes.
+    val currentKonstruction by konstructionVm.currentKonstruction.collectAsState()
+
+    // Flag-gated LSP editor support (epic #35). When the flag is OFF this stays
+    // null and the editor is byte-for-byte identical to before. When ON, build
+    // the LSP session for the current konstruction and expose its editor
+    // extension; rebuilt whenever the flag or the loaded konstruction changes.
+    val lspExtension: Extension? = produceState<Extension?>(
+        initialValue = null,
+        key1 = lspEnabled,
+        key2 = currentKonstruction
+    ) {
+        value = null
+        if (!lspEnabled) return@produceState
+        val konstruction = currentKonstruction ?: return@produceState
+        val service = konstructionVm.currentService ?: return@produceState
+        // Stable per-konstruction document URI for the LSP session.
+        val uri = "file:///${konstruction.workspaceId}/${konstruction.id}/content.csgs"
+        try {
+            // The editor client receives server→client pushes (publishDiagnostics)
+            // over the reverse channel multiplexed onto the same WebSocket. It is
+            // bound to kodemirror's routing client once the LSPClient exists.
+            val editorLspClient = EditorLspClient(
+                onDiagnostics = { params -> reportLspDiagnostics(uri, params.diagnostics.size) }
+            )
+            // Open the nested ksrpc LSP sub-service; the returned stub IS-A
+            // LanguageServer, so it drops straight into kodemirror's LSPClient.
+            val server = service.lsp(editorLspClient)
+            val lspClient = LSPClient(
+                server = server,
+                config = LSPClientConfig(rootUri = "file:///${konstruction.workspaceId}")
+            )
+            editorLspClient.bind(lspClient.languageClient)
+            lspClient.initialize()
+            value = languageServerSupport(lspClient, uri, "kotlin")
+        } catch (_: Throwable) {
+            value = null
+        }
+    }.value
 
     // The Vim mapping engine is a global singleton, so apply/restore the j/k →
     // gj/gk remapping imperatively (rather than as an editor extension) and tie
@@ -245,8 +292,10 @@ private fun EditorContent(
     // onto up-to-date line positions. Updated below whenever messages change.
     val messagesHolder = remember(selectedKonId) { mutableStateOf<List<Diagnostic>>(emptyList()) }
 
-    // Recreate session when konstruction, theme, or keymap changes
-    val session = remember(selectedKonId, themeName, keymapName, monoFont) {
+    // Recreate session when konstruction, theme, keymap, or LSP support changes.
+    // lspExtension is null with the flag OFF, so the extensions chain (and thus
+    // the session) is unchanged from before in that case.
+    val session = remember(selectedKonId, themeName, keymapName, monoFont, lspExtension) {
         // Lint extension: decorates offending lines (red error / orange warning),
         // adds gutter markers, and shows message text on hover. The source reads
         // pre-built diagnostics from the holder; setDiagnostics-driven updates
@@ -258,8 +307,13 @@ private fun EditorContent(
             source = lintSource,
             config = LintConfig(delay = 0)
         )
-        val extensions = basicSetup + themeExt + fontExt + kotlinLang +
+        var extensions = basicSetup + themeExt + fontExt + kotlinLang +
             keymapExt + saveKeymap + saveExt + lintExt + lintGutter() + lineWrapping
+        // Append LSP editor support only when the flag is on and the session is
+        // ready (lspExtension non-null) — keeps the flag-OFF path identical.
+        if (lspExtension != null) {
+            extensions = extensions + lspExtension
+        }
         val config = com.monkopedia.kodemirror.state.EditorStateConfig(
             doc = content.asDoc(),
             extensions = extensions

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
@@ -88,6 +88,23 @@ class KonstructionViewModel(
     private var konstructionService: KonstructionService? = null
     private var listenerKey: String? = null
 
+    /**
+     * The currently-loaded konstruction (set in [loadKonstruction]), exposed so
+     * the editor can open a flag-gated LSP session against the right service +
+     * derive a stable document URI. Null until a konstruction is loaded.
+     */
+    private val _currentKonstruction = MutableStateFlow<Konstruction?>(null)
+    val currentKonstruction: StateFlow<Konstruction?> = _currentKonstruction.asStateFlow()
+
+    /**
+     * The [KonstructionService] for the currently-loaded konstruction, or null.
+     * Read by the editor's flag-gated LSP wiring to call
+     * [KonstructionService.lsp]. Identity matches the service captured during
+     * [loadKonstruction].
+     */
+    val currentService: KonstructionService?
+        get() = konstructionService
+
     // Targets currently being auto-fetched/built via setTargetEnabled, to avoid
     // kicking off duplicate work for the same target.
     private val inFlightEnables = mutableSetOf<String>()
@@ -116,6 +133,7 @@ class KonstructionViewModel(
             val previousKey = listenerKey
             konstructionService = null
             listenerKey = null
+            _currentKonstruction.value = null
             if (previousKs != null && previousKey != null) {
                 try {
                     previousKs.unregister(previousKey)
@@ -132,6 +150,7 @@ class KonstructionViewModel(
             try {
                 val ks = service.konstruction(konstruction)
                 konstructionService = ks
+                _currentKonstruction.value = konstruction
 
                 // STL files: show directly in 3D pane, no editor content
                 if (konstruction.type == KonstructionType.STL) {

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
@@ -81,6 +81,11 @@ class SettingsViewModel {
         PersistedStateFlow.enum("keymap", KeymapName.VIM)
     private val vimDisplayLineMotionStore =
         PersistedStateFlow.boolean("vimDisplayLineMotion", false)
+
+    // LSP editor support (epic #35). Default OFF: with this off the editor
+    // behaves byte-for-byte as before — no lsp() call, no languageServerSupport.
+    private val lspEnabledStore =
+        PersistedStateFlow.boolean("lspEnabled", false)
     private val showCodeLeftStore =
         PersistedStateFlow.boolean("showCodeLeft", false)
     private val showFpsStore =
@@ -99,6 +104,7 @@ class SettingsViewModel {
     val editorTheme: StateFlow<EditorThemeName> = editorThemeStore.flow
     val keymap: StateFlow<KeymapName> = keymapStore.flow
     val vimDisplayLineMotion: StateFlow<Boolean> = vimDisplayLineMotionStore.flow
+    val lspEnabled: StateFlow<Boolean> = lspEnabledStore.flow
     val showCodeLeft: StateFlow<Boolean> = showCodeLeftStore.flow
     val showFps: StateFlow<Boolean> = showFpsStore.flow
     val showCameraWidget: StateFlow<Boolean> = showCameraWidgetStore.flow
@@ -111,6 +117,7 @@ class SettingsViewModel {
     fun setEditorTheme(theme: EditorThemeName) = editorThemeStore.set(theme)
     fun setKeymap(keymap: KeymapName) = keymapStore.set(keymap)
     fun setVimDisplayLineMotion(value: Boolean) = vimDisplayLineMotionStore.set(value)
+    fun setLspEnabled(value: Boolean) = lspEnabledStore.set(value)
     fun setShowCodeLeft(value: Boolean) = showCodeLeftStore.set(value)
     fun setShowFps(value: Boolean) = showFpsStore.set(value)
     fun setShowCameraWidget(value: Boolean) = showCameraWidgetStore.set(value)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ javafx = "0.1.0"
 compose-multiplatform = "1.10.3"
 lifecycle = "2.10.0"
 kodemirror = "0.3.2"
+lsp = "1.0.0"
 spotless = "8.4.0"
 ktlint = "1.8.0"
 
@@ -57,6 +58,7 @@ kotlinx-serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlin-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin-serialization" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
+lsp-ksrpc = { module = "com.monkopedia.lsp:lsp-ksrpc", version.ref = "lsp" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -33,6 +33,10 @@ kotlin {
     sourceSets["commonMain"].dependencies {
         api(libs.ksrpc.core)
         api(libs.ksrpc.binary.ktor)
+        // LSP @KsService interfaces (KsrpcLanguageServer / KsrpcLanguageClient)
+        // appear in the public KonstructionService surface (the /lsp sub-service)
+        // — must be api so consumers don't have to redeclare lsp-ksrpc.
+        api(libs.lsp.ksrpc)
         api(libs.hauler)
         api(libs.kotlinx.datetime)
         // ByteReadChannel is in the public KonstructionService surface —

--- a/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructionService.kt
+++ b/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructionService.kt
@@ -20,6 +20,8 @@ import com.monkopedia.ksrpc.RpcBidiService
 import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.lsp.KsrpcLanguageClient
+import com.monkopedia.lsp.KsrpcLanguageServer
 import io.ktor.utils.io.ByteReadChannel
 
 @KsService
@@ -68,6 +70,21 @@ interface KonstructionService : RpcBidiService {
 
     @KsMethod("/logging")
     suspend fun getShipper(u: Unit = Unit): Shipper
+
+    /**
+     * Open an LSP session for this konstruction, behind the editor's LSP flag.
+     *
+     * This is a nested ksrpc sub-service: it both *returns* a sub-service
+     * ([KsrpcLanguageServer], client→server) and *accepts* one as a param
+     * ([KsrpcLanguageClient], server→client) — ksrpc multiplexes the reverse
+     * `publishDiagnostics` channel onto the same WebSocket, so no second
+     * connection is needed. Because this method both returns and accepts a
+     * sub-service, [KonstructionService] must extend [RpcBidiService] (the
+     * ksrpc compile-time tier); the passed/returned types stay plain
+     * [RpcService].
+     */
+    @KsMethod("/lsp")
+    suspend fun lsp(client: KsrpcLanguageClient): KsrpcLanguageServer
 }
 
 @KsService


### PR DESCRIPTION
First phase of the LSP epic (#35). Proves the LSP message pipe end-to-end with a **stub** server — no real Kotlin LSP engine yet. **Additive + flag-gated**: with `lspEnabled` OFF the editor behaves byte-for-byte as today.

## protocol/
- Add `com.monkopedia.lsp:lsp-ksrpc:1.0.0` (as `api`, since the `@KsService` LSP interfaces appear in the public `KonstructionService` surface). Built against ksrpc 1.1.0 / Kotlin 2.3.20 = our versions.
- `KonstructionService` gains the nested LSP sub-service:
  ```kotlin
  @KsMethod("/lsp")
  suspend fun lsp(client: KsrpcLanguageClient): KsrpcLanguageServer
  ```
  Passing `KsrpcLanguageClient` as a **param** lets ksrpc multiplex the reverse `publishDiagnostics` channel onto the same WebSocket (no second connection, no `connectAsLspServer`). `KonstructionService` already extended `RpcBidiService` (required because `lsp()` both returns and accepts a sub-service), so **the tier bump did not ripple** into `Konstructor`/`Workspace`.

## backend
- `StubLanguageServer` (subclass `DefaultLanguageServer`): canned `InitializeResult` advertising hover + completion; on `textDocument/didOpen` pushes one canned `publishDiagnostics` (a single fake warning) back through the held `KsrpcLanguageClient`.
- `KonstructionServiceImpl.lsp(client)` stashes the client and returns the stub, served through the existing ksrpc graph.

## frontend (wasmJs) — behind the `lspEnabled` flag, default OFF
- Add kodemirror `lsp-client` + `lsp-ksrpc` deps.
- `EditorLspClient` (a `KsrpcLanguageClient`) routes server-pushed diagnostics into kodemirror's `LSPClient.languageClient`.
- `EditorPane` builds `LSPClient(server = lsp(EditorLspClient()))` and appends `languageServerSupport(...)` to the editor extensions **only when the flag is on and the session is ready** — OFF leaves the extensions chain identical to before.
- `SettingsViewModel.lspEnabled` (`PersistedStateFlow`, default `false`).

## e2e
- `LspPipeTest`: with the flag ON, opening a konstruction round-trips the canned `publishDiagnostics` back to the editor (`count=1`, asserted via a JS-bridge hook).

## Verification
- Whole project compiles (RpcBidiService bump broke nothing).
- Full clean `:e2e:test` green — flag-OFF suite unchanged + flag-ON round-trip proven (`LSP diagnostics received: count=1 uri=file:///0/0/content.csgs`).
- `spotlessCheck` clean; backend + protocol unit tests pass.

Part of #35; Fixes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)