### PR TITLE
LSP Phase 3: diagnostics through the header-line translation layer

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -42,9 +42,11 @@ import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
 import com.monkopedia.lsp.SignatureHelp
 import com.monkopedia.lsp.SignatureHelpParams
 import com.monkopedia.lsp.TextDocumentCompletionResult
+import com.monkopedia.lsp.TextDocumentContentChangeEventVariant
 import com.monkopedia.lsp.TextDocumentIdentifier
 import com.monkopedia.lsp.TextDocumentItem
 import com.monkopedia.lsp.UnregistrationParams
+import com.monkopedia.lsp.VersionedTextDocumentIdentifier
 import com.monkopedia.lsp.ksrpc.LifecycleState
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -70,8 +72,10 @@ import kotlinx.serialization.json.JsonNull
  *   document URI).
  * - The subprocess-facing stub is obtained from [KotlinLspProcess.connect], passing
  *   [Forwarder] as the subprocess's client.
- * - Requests are **delegated** to the subprocess stub; positions stay in WRAPPED-`.kt`
- *   space for Phase 2 (the ±3-line translation is Phase 3 / #38).
+ * - Requests are **delegated** to the subprocess stub. Diagnostic ranges coming back are
+ *   translated from WRAPPED-`.kt` space down to csgs space (Phase 3 / #38) via
+ *   [DiagnosticTranslation]; completion/hover positions stay in wrapped space (Phase 4 /
+ *   #39).
  *
  * **Pull→push diagnostics bridge.** kotlin-lsp does NOT proactively push
  * `publishDiagnostics`; it answers PULL `textDocument/diagnostic`. kodemirror's editor
@@ -113,8 +117,8 @@ class BridgeLanguageServer(
     /**
      * The frontend's document URI (`...content.csgs`), captured on the editor's first
      * didOpen. Diagnostics from the subprocess (on the wrapped-`.kt` URI) are rewritten
-     * to this URI so kodemirror routes them to the open editor. Positions stay in
-     * wrapped-`.kt` space for Phase 2.
+     * to this URI so kodemirror routes them to the open editor, and their ranges are
+     * translated to csgs space (Phase 3 / #38).
      */
     @Volatile
     private var frontendUri: String? = null
@@ -130,7 +134,12 @@ class BridgeLanguageServer(
             // Don't push before the editor has sent `initialized` (spec ordering; some
             // clients silently drop early diagnostics).
             lifecycle.awaitInitialized()
-            val mapped = frontendUri?.let { params.copy(uri = it) } ?: params
+            // Rewrite the wrapped-.kt URI back to the editor's csgs URI AND translate every
+            // range from wrapped-.kt space down to csgs space (Phase 3 / #38).
+            val mapped = params.copy(
+                uri = frontendUri ?: params.uri,
+                diagnostics = translateDiagnostics(params.diagnostics)
+            )
             runCatching { frontendClient.textDocumentPublishDiagnostics(mapped) }
                 .onFailure { hauler.error("Failed forwarding diagnostics to editor", it) }
         }
@@ -174,8 +183,10 @@ class BridgeLanguageServer(
         val server = delegate ?: return
         // Remember the editor's URI so subprocess diagnostics get routed back to it.
         frontendUri = params.textDocument.uri
-        // Re-synthesize from the latest content and open the WRAPPED file in the engine.
-        lspWorkspace.synthesize()
+        // Wrap the editor's LIVE csgs content (not just the stored snapshot) into the .kt
+        // form and open the WRAPPED file in the engine, so the engine analyzes what the
+        // user actually has open.
+        lspWorkspace.synthesize(content = params.textDocument.text)
         server.textDocumentDidOpen(
             DidOpenTextDocumentParams(
                 textDocument = TextDocumentItem(
@@ -207,9 +218,11 @@ class BridgeLanguageServer(
                     .getOrNull()
                 if (items != null) {
                     val uri = frontendUri ?: lspWorkspace.documentUri
+                    // Translate wrapped-.kt ranges down to csgs space before pushing up.
+                    val translated = translateDiagnostics(items)
                     runCatching {
                         frontendClient.textDocumentPublishDiagnostics(
-                            PublishDiagnosticsParams(uri = uri, diagnostics = items)
+                            PublishDiagnosticsParams(uri = uri, diagnostics = translated)
                         )
                     }.onFailure { hauler.error("publish diagnostics to editor failed", it) }
                 }
@@ -231,9 +244,30 @@ class BridgeLanguageServer(
     }
 
     override suspend fun textDocumentDidChange(params: DidChangeTextDocumentParams) {
-        // Phase 2 keeps the engine's view in wrapped-.kt space; content sync from the
-        // editor (with the ±3-line translation) is Phase 3. Drop change events for now —
-        // didOpen already seeds the document for diagnostics.
+        val server = delegate ?: return
+        // Full-document sync (v1): the editor sends the whole edited csgs as the change
+        // text (kodemirror full-sync; these files are tiny). Take the last change's text
+        // as the live document, re-wrap it into the .kt form so the engine analyzes the
+        // current content, and forward the WRAPPED text down as a full-document change.
+        val csgsText = params.contentChanges
+            .filterIsInstance<TextDocumentContentChangeEventVariant>()
+            .lastOrNull()?.text ?: return
+        lspWorkspace.synthesize(content = csgsText)
+        runCatching {
+            server.textDocumentDidChange(
+                DidChangeTextDocumentParams(
+                    textDocument = VersionedTextDocumentIdentifier(
+                        uri = lspWorkspace.documentUri,
+                        version = params.textDocument.version
+                    ),
+                    contentChanges = listOf(
+                        TextDocumentContentChangeEventVariant(text = lspWorkspace.wrappedText())
+                    )
+                )
+            )
+        }.onFailure { hauler.error("Failed forwarding didChange to engine", it) }
+        // Refresh diagnostics for the new content (re-poll; same path as didOpen).
+        startDiagnosticsPoll(server)
     }
 
     override suspend fun textDocumentDidClose(params: DidCloseTextDocumentParams) {
@@ -285,6 +319,14 @@ class BridgeLanguageServer(
         }
         delegate = null
     }
+
+    /**
+     * Translate engine diagnostics (wrapped-`.kt` space) down to csgs space, dropping any
+     * that fall in the wrapping header/footer (a synthetic line the user can't fix). See
+     * [DiagnosticTranslation]; the csgs line count is the live document last synthesized.
+     */
+    private fun translateDiagnostics(diagnostics: List<Diagnostic>): List<Diagnostic> =
+        DiagnosticTranslation.translateDiagnostics(diagnostics, lspWorkspace.csgsLineCount())
 
     private fun CompletionParams.onWrappedDocument(): CompletionParams =
         copy(textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri))

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslation.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslation.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.lsp
+
+import com.monkopedia.kcsg.KcsgScript
+import com.monkopedia.lsp.Diagnostic
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+
+/**
+ * The header-line position translation for LSP Phase 3 (#38).
+ *
+ * konstructor wraps the user's `csgs` into a `.kt` with a fixed header
+ * ([KcsgScript.HEADER]) + a `}` footer ([KcsgScript.FOOTER]) before the compiler/engine
+ * sees it — see
+ * [com.monkopedia.konstructor.KonstructionControllerImpl.copyContentToScript]. The
+ * kotlin-lsp engine therefore reports diagnostics in **wrapped-`.kt` space**: a squiggle
+ * for the user's csgs line N arrives as wrapped line `N + headerLines`.
+ *
+ * This object translates engine ranges back to **csgs space** so squiggles land on the
+ * correct line:
+ *
+ * ```
+ * csgsLine = ktLine - headerLines
+ * ```
+ *
+ * The header adds whole lines at column 0, so columns are unchanged. Diagnostics whose
+ * line falls in the header (`ktLine < headerLines`) or the footer (beyond the user's
+ * content) are **dropped** — a wrapping artifact the user can neither see nor fix must
+ * never light up a wrong line. This mirrors the compiler-error handling in
+ * [com.monkopedia.konstructor.tasks.CompileTask], which clamps/drops the same way.
+ *
+ * [headerLines] is computed from the SAME source of truth the backend already uses
+ * ([KcsgScript.HEADER]`.split("\n").size`, = 3), so the offset cannot drift from the
+ * compiler's view.
+ */
+object DiagnosticTranslation {
+
+    /**
+     * The number of header lines konstructor prepends when wrapping a csgs into a `.kt`.
+     * Same computation as [com.monkopedia.konstructor.tasks.CompileTask]. Currently 3.
+     */
+    val headerLines: Int = KcsgScript.HEADER.split("\n").size
+
+    /**
+     * Translate a single engine [Position] (wrapped-`.kt`, zero-based) to csgs space, or
+     * return `null` if it falls in the header or in/after the footer.
+     *
+     * @param csgsLineCount the number of lines in the user's csgs document; lines at or
+     *   beyond `headerLines + csgsLineCount` are footer/synthetic and are dropped.
+     */
+    fun translatePosition(position: Position, csgsLineCount: Int): Position? {
+        val ktLine = position.line.toInt()
+        if (ktLine < headerLines) return null
+        val csgsLine = ktLine - headerLines
+        if (csgsLine >= csgsLineCount) return null
+        // Columns are unchanged: the header adds whole lines at column 0.
+        return Position(line = csgsLine.toUInt(), character = position.character)
+    }
+
+    /**
+     * Translate an engine [Range] (wrapped-`.kt`) to csgs space. Returns `null` (drop the
+     * diagnostic) if the range's START is in the header or in/after the footer. The END is
+     * translated when it maps; otherwise it is clamped to the translated start so the
+     * range stays well-formed and entirely inside the user's content.
+     */
+    fun translateRange(range: Range, csgsLineCount: Int): Range? {
+        val start = translatePosition(range.start, csgsLineCount) ?: return null
+        val end = translatePosition(range.end, csgsLineCount) ?: start
+        return Range(start = start, end = end)
+    }
+
+    /**
+     * Translate one engine [Diagnostic] to csgs space, or `null` if its range is in the
+     * header/footer and should be dropped.
+     */
+    fun translateDiagnostic(diagnostic: Diagnostic, csgsLineCount: Int): Diagnostic? {
+        val range = translateRange(diagnostic.range, csgsLineCount) ?: return null
+        return diagnostic.copy(range = range)
+    }
+
+    /**
+     * Translate a list of engine diagnostics to csgs space, dropping any that fall in the
+     * header or footer.
+     */
+    fun translateDiagnostics(diagnostics: List<Diagnostic>, csgsLineCount: Int): List<Diagnostic> =
+        diagnostics.mapNotNull { translateDiagnostic(it, csgsLineCount) }
+}

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KonstructionLspWorkspace.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KonstructionLspWorkspace.kt
@@ -66,28 +66,45 @@ class KonstructionLspWorkspace(
     val documentUri: String = fileUri(wrappedFile)
 
     /**
+     * The csgs content most recently wrapped into the `.kt`. Defaults to the stored
+     * snapshot on disk; [synthesize] with explicit text (the editor's live document)
+     * overwrites it so the engine analyzes what the user is currently editing, not a
+     * stale file. Drives [csgsLineCount], used by the Phase 3 footer-drop translation.
+     */
+    @Volatile
+    private var csgsContent: String = readStoredContent()
+
+    /**
      * (Re)write the wrapped `.kt` from the latest konstruction content and the
      * `workspace.json` pointing at this dir + the resolved `lib.jar`. Idempotent;
      * call before opening / on content change.
+     *
+     * @param content the live editor csgs text to wrap (full-document sync). When null,
+     *   the stored on-disk snapshot is used.
      */
-    fun synthesize() {
-        writeWrappedKt()
+    fun synthesize(content: String? = null) {
+        csgsContent = content ?: readStoredContent()
+        writeWrappedKt(csgsContent)
         writeWorkspaceJson()
     }
 
     /** The current wrapped-document text (post-wrapping). */
     fun wrappedText(): String = wrappedFile.readText()
 
-    private fun writeWrappedKt() {
-        val source =
-            if (paths.contentFile.exists()) {
-                paths.contentFile.inputStream()
-            } else {
-                "".byteInputStream()
-            }
+    /**
+     * Number of lines in the csgs content last [synthesize]d — the user-visible line
+     * count. Used by the Phase 3 translation to drop footer diagnostics (any wrapped
+     * line at/after `headerLines + csgsLineCount`).
+     */
+    fun csgsLineCount(): Int = csgsContent.split("\n").size
+
+    private fun readStoredContent(): String =
+        if (paths.contentFile.exists()) paths.contentFile.readText() else ""
+
+    private fun writeWrappedKt(content: String) {
         // Reuse konstructor's EXACT compiler wrapping (header swap + footer) so LSP
         // positions match the compiler's view of the script.
-        KonstructionControllerImpl.copyContentToScript(source, wrappedFile)
+        KonstructionControllerImpl.copyContentToScript(content.byteInputStream(), wrappedFile)
     }
 
     private fun writeWorkspaceJson() {

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
@@ -154,13 +154,33 @@ class BridgeLanguageServerIntegrationTest {
             "expected at least one diagnostic for the deliberate error; got none"
         )
         System.err.println("REAL-ENGINE diagnostics (${received.diagnostics.size}): $messages")
+        val unresolved = received.diagnostics.firstOrNull {
+            it.message.contains("thisSymbolDoesNotExist123") ||
+                it.message.contains("unresolved", ignoreCase = true) ||
+                it.message.contains("cannot access", ignoreCase = true)
+        }
         assertTrue(
-            received.diagnostics.any {
-                it.message.contains("thisSymbolDoesNotExist123") ||
-                    it.message.contains("unresolved", ignoreCase = true) ||
-                    it.message.contains("cannot access", ignoreCase = true)
-            },
+            unresolved != null,
             "expected the unresolved-reference error to be reported; got: $messages"
         )
+        // Phase 3 (#38): the deliberate error is on csgs line index 1 (the `val broken`
+        // line, 0-based). The engine reports it on wrapped line `1 + headerLines`; after
+        // the translation it MUST land back on csgs line 1 (not N+headerLines). This is
+        // the real-engine half of the round-trip guard.
+        System.err.println(
+            "REAL-ENGINE unresolved-ref range: ${unresolved.range.start.line.toInt()}.." +
+                "${unresolved.range.end.line.toInt()}"
+        )
+        assertTrue(
+            unresolved.range.start.line.toInt() == EXPECTED_CSGS_ERROR_LINE,
+            "translated diagnostic must land on csgs line $EXPECTED_CSGS_ERROR_LINE " +
+                "(the `val broken` line), not the wrapped-.kt line; " +
+                "got line ${unresolved.range.start.line.toInt()}"
+        )
+    }
+
+    private companion object {
+        /** The `val broken = thisSymbolDoesNotExist123` line in [deliberateErrorScript]. */
+        private const val EXPECTED_CSGS_ERROR_LINE = 1
     }
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslationTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.lsp
+
+import com.monkopedia.kcsg.KcsgScript
+import com.monkopedia.konstructor.KonstructionControllerImpl
+import com.monkopedia.lsp.Diagnostic
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import java.io.File
+import kotlin.io.path.createTempFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The maintainer-flagged round-trip test for LSP Phase 3 (#38): the header-line
+ * csgs↔wrapped-`.kt` translation interacts directly with diagnostic **ranges** — an
+ * off-by-N silently lights the wrong line. This is the CI-runnable guard (the real-engine
+ * one lives in [com.monkopedia.konstructor.integration.BridgeLanguageServerIntegrationTest],
+ * CI-skipped).
+ *
+ * The core round-trip: take a known kcsg error on a known csgs line, run it through the
+ * SAME wrapping konstructor feeds the compiler/engine ([KonstructionControllerImpl.copyContentToScript]),
+ * compute the wrapped-`.kt` line the engine would report it on, translate that range back,
+ * and assert it lands on the ACTUAL csgs error line (not N±offset).
+ */
+class DiagnosticTranslationTest {
+
+    /** The header that konstructor prepends; the engine reports csgs line N at N + this. */
+    private val headerLines = KcsgScript.HEADER.split("\n").size
+
+    private fun pos(line: Int, character: Int = 0): Position =
+        Position(line = line.toUInt(), character = character.toUInt())
+
+    private fun range(startLine: Int, endLine: Int = startLine): Range =
+        Range(start = pos(startLine), end = pos(endLine))
+
+    private fun diag(range: Range, message: String = "boom"): Diagnostic =
+        Diagnostic(range = range, message = message)
+
+    @Test
+    fun `headerLines matches the backend source of truth`() {
+        // Same computation CompileTask uses; the wrapping header is currently 3 lines.
+        assertEquals(3, headerLines, "header is import + blank + main-invocation line")
+        assertEquals(headerLines, DiagnosticTranslation.headerLines)
+    }
+
+    @Test
+    fun `round-trip a known kcsg error lands on the exact csgs line`() {
+        // A 3-line csgs with a deliberate error on csgs line index 1 (the second line).
+        val csgs = """
+            val ok by primitive { cube { dimensions = xyz(1.0, 1.0, 1.0) } }
+            val broken = thisSymbolDoesNotExist123
+            export("ok")
+        """.trimIndent()
+        val csgsLineCount = csgs.split("\n").size
+        val csgsErrorLine = 1
+
+        // Wrap EXACTLY as konstructor feeds the compiler/engine.
+        val wrapped: File = createTempFile(suffix = ".kt").toFile()
+        KonstructionControllerImpl.copyContentToScript(csgs.byteInputStream(), wrapped)
+        val wrappedLines = wrapped.readLines()
+
+        // Sanity: the engine sees the error on (csgs line + headerLines). Prove that's the
+        // line the broken symbol actually lives on in the wrapped file.
+        val engineLine = csgsErrorLine + headerLines
+        assertTrue(
+            wrappedLines[engineLine].contains("thisSymbolDoesNotExist123"),
+            "wrapped line $engineLine should hold the deliberate error; " +
+                "got: ${wrappedLines[engineLine]}"
+        )
+
+        // Engine reports the diagnostic on the wrapped line; translate it back.
+        val engineDiag = diag(range(engineLine), message = "unresolved reference")
+        val translated = DiagnosticTranslation.translateDiagnostic(engineDiag, csgsLineCount)
+
+        assertNotNull(translated, "a user-line diagnostic must survive translation")
+        assertEquals(
+            csgsErrorLine.toUInt(),
+            translated.range.start.line,
+            "translated diagnostic must land on the exact csgs error line, not N±offset"
+        )
+        assertEquals(csgsErrorLine.toUInt(), translated.range.end.line)
+        wrapped.delete()
+    }
+
+    @Test
+    fun `user-line error subtracts the header exactly`() {
+        val character = 7
+        val engineDiag = diag(
+            Range(
+                start = pos(headerLines + 0, character),
+                end = pos(headerLines + 0, character + 5)
+            )
+        )
+        val translated = DiagnosticTranslation.translateDiagnostic(engineDiag, csgsLineCount = 3)
+        assertNotNull(translated)
+        // First user line -> csgs line 0; columns unchanged (header adds whole lines at 0).
+        assertEquals(0u, translated.range.start.line)
+        assertEquals(character.toUInt(), translated.range.start.character)
+        assertEquals(0u, translated.range.end.line)
+        assertEquals((character + 5).toUInt(), translated.range.end.character)
+    }
+
+    @Test
+    fun `header-line error is dropped`() {
+        // ktLine 0,1,2 are all header (import / blank / main-invocation) -> never shown.
+        for (headerLine in 0 until headerLines) {
+            assertNull(
+                DiagnosticTranslation.translateDiagnostic(
+                    diag(range(headerLine)),
+                    csgsLineCount = 3
+                ),
+                "a diagnostic on header line $headerLine must be dropped"
+            )
+        }
+    }
+
+    @Test
+    fun `footer error is dropped`() {
+        // 2 csgs lines occupy wrapped lines headerLines..headerLines+1; the `}` footer is
+        // at headerLines+2 and beyond -> must be dropped.
+        val csgsLineCount = 2
+        val footerLine = headerLines + csgsLineCount
+        assertNull(
+            DiagnosticTranslation.translateDiagnostic(diag(range(footerLine)), csgsLineCount),
+            "a diagnostic on the footer line must be dropped"
+        )
+        assertNull(
+            DiagnosticTranslation.translateDiagnostic(diag(range(footerLine + 5)), csgsLineCount),
+            "a diagnostic beyond the footer must be dropped"
+        )
+    }
+
+    @Test
+    fun `boundary lines map correctly`() {
+        val csgsLineCount = 4
+        // Last header line -> dropped.
+        assertNull(
+            DiagnosticTranslation.translateDiagnostic(diag(range(headerLines - 1)), csgsLineCount)
+        )
+        // First user line -> csgs line 0.
+        assertEquals(
+            0u,
+            DiagnosticTranslation.translateDiagnostic(diag(range(headerLines)), csgsLineCount)
+                ?.range?.start?.line
+        )
+        // Last user line -> csgs line (count-1).
+        val lastUserKtLine = headerLines + csgsLineCount - 1
+        assertEquals(
+            (csgsLineCount - 1).toUInt(),
+            DiagnosticTranslation.translateDiagnostic(diag(range(lastUserKtLine)), csgsLineCount)
+                ?.range?.start?.line
+        )
+        // One past the last user line (footer) -> dropped.
+        assertNull(
+            DiagnosticTranslation.translateDiagnostic(
+                diag(range(headerLines + csgsLineCount)),
+                csgsLineCount
+            )
+        )
+    }
+
+    @Test
+    fun `range straddling into the footer clamps its end to the start`() {
+        // A range that starts on the last user line but whose end spills into the footer
+        // must stay inside the user's content (end clamped to start), never reported on a
+        // synthetic line.
+        val csgsLineCount = 2
+        val startKt = headerLines + 1 // last user line
+        val endKt = headerLines + 2 // footer
+        val translated = DiagnosticTranslation.translateDiagnostic(
+            diag(Range(start = pos(startKt, 3), end = pos(endKt, 1))),
+            csgsLineCount
+        )
+        assertNotNull(translated)
+        assertEquals(1u, translated.range.start.line)
+        assertEquals(translated.range.start, translated.range.end, "end clamped to start")
+    }
+
+    @Test
+    fun `translateDiagnostics drops header and footer entries but keeps user ones`() {
+        val csgsLineCount = 2
+        val all = listOf(
+            diag(range(0), "header"), // dropped
+            diag(range(headerLines), "user-0"), // kept -> csgs 0
+            diag(range(headerLines + 1), "user-1"), // kept -> csgs 1
+            diag(range(headerLines + 2), "footer") // dropped
+        )
+        val out = DiagnosticTranslation.translateDiagnostics(all, csgsLineCount)
+        assertEquals(listOf("user-0", "user-1"), out.map { it.message })
+        assertEquals(listOf(0u, 1u), out.map { it.range.start.line })
+    }
+}


### PR DESCRIPTION
## What

Phase 3 of the LSP epic (#35). Phase 2 (#42) forwards **real** kotlin-lsp diagnostics, but their positions stayed in **wrapped-`.kt` space**, so a squiggle for the user's csgs line N arrived on line N+headerLines (off by the fixed 3-line header). This phase adds the **two-direction translation** so diagnostics land on the **correct csgs line**.

Fully **flag-gated** (`lspEnabled` default OFF + engine-gated); flag-off ⇒ no behavior change. The change is contained to the `lsp/` bridge.

## The translation (both directions)

**Direction 1 — document content IN (editor → engine).** `textDocument/didOpen` and `textDocument/didChange` now **wrap the editor's LIVE csgs content** into the `.kt` form before forwarding to the engine, so the engine analyzes what the user is currently editing rather than a stale stored snapshot. `didChange` does **full-document sync for v1** (re-wrap the whole tiny doc, forward as a full-document change). Wrapping reuses konstructor's exact `KonstructionControllerImpl.copyContentToScript` (header swap + footer), so positions line up with the compiler.

**Direction 2 — diagnostic positions OUT (engine → editor).** When forwarding the engine's diagnostics up as `publishDiagnostics` (both in the `Forwarder` push path and the pull-poll push path), every range is translated from `.kt`-space to csgs-space:

```
csgsLine = ktLine - headerLines
```

`headerLines` reuses the **same source of truth** the backend already uses — `KcsgScript.HEADER.split("\n").size` (= 3), exactly as `CompileTask` computes it (not hardcoded). Columns are unchanged (the header adds whole lines at column 0). Diagnostics whose line falls in the **header** (`ktLine < headerLines`) or the **footer/beyond the user's content** are **dropped**, and a range that spills into the footer clamps its end inside the user's content — mirroring `CompileTask`'s existing compile-error handling (a wrapping artifact the user can't fix must never light a wrong line).

The math lives in a new pure `DiagnosticTranslation` object in `lsp/`. Completion/hover positions are **untouched** (Phase 4 / #39); the diagnostics delivery model (blind-poll) is **untouched** (#43).

## The round-trip test (maintainer-flagged)

- **`DiagnosticTranslationTest` (CI-runnable, the guard):** the core round-trip wraps a known kcsg error via `copyContentToScript`, asserts the broken symbol actually lives on the computed wrapped line, then translates that engine range back and asserts it lands on the **exact csgs error line** (not N±offset). Plus: user-line subtraction, header-line drop, footer drop, boundary lines, and footer-clamp. **8 tests, all green.**
- **`BridgeLanguageServerIntegrationTest` (local real-engine, CI-skipped)** extended to assert the deliberate error lands on **csgs line 1** (the `val broken` line), not the wrapped line.

## Verification

**Flag-OFF / CI-equivalent — green:**
- `./gradlew test` (incl. the new 8 translation tests) ✅
- `./gradlew spotlessCheck` ✅
- Full `:e2e:test` flag-off via the Mesa-EGL/xvfb env, `clean`, JDK 21 — **43 tests, 0 failures/errors** (6 LSP-gated skips) ✅

**Real engine (LOCAL ONLY — CI has no binary):** ran the integration test against `KONSTRUCTOR_KOTLIN_LSP=/tmp/kotlin-lsp-poc/server/kotlin-server-262.4739.0/bin/intellij-server`. The unresolved-reference diagnostic (`Unresolved reference 'thisSymbolDoesNotExist123'`) now reports on **csgs line 1 (range 1..1)**.

Before/after line math (real engine): the error is on csgs line 1; the engine reports it on wrapped line **4** (1 + 3 header lines); **before** this phase it surfaced on line 4, **after** it lands on line **1**. ✅ (Engine path is not CI-tested — no binary in CI.)

Part of #35; Fixes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)