### PR TITLE
LSP Phase 4: completion + hover + signatureHelp

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -18,6 +18,8 @@ package com.monkopedia.konstructor.lsp
 import com.monkopedia.hauler.error
 import com.monkopedia.hauler.hauler
 import com.monkopedia.konstructor.Config
+import com.monkopedia.lsp.CompletionItem
+import com.monkopedia.lsp.CompletionItemTextEdit
 import com.monkopedia.lsp.CompletionParams
 import com.monkopedia.lsp.ConfigurationParams
 import com.monkopedia.lsp.DefaultLanguageClient
@@ -31,6 +33,7 @@ import com.monkopedia.lsp.DocumentDiagnosticReport
 import com.monkopedia.lsp.Hover
 import com.monkopedia.lsp.HoverParams
 import com.monkopedia.lsp.InitializeParams
+import com.monkopedia.lsp.InsertReplaceEdit
 import com.monkopedia.lsp.InitializeResult
 import com.monkopedia.lsp.InitializedParams
 import com.monkopedia.lsp.KsrpcLanguageClient
@@ -45,6 +48,7 @@ import com.monkopedia.lsp.TextDocumentCompletionResult
 import com.monkopedia.lsp.TextDocumentContentChangeEventVariant
 import com.monkopedia.lsp.TextDocumentIdentifier
 import com.monkopedia.lsp.TextDocumentItem
+import com.monkopedia.lsp.TextEdit
 import com.monkopedia.lsp.UnregistrationParams
 import com.monkopedia.lsp.VersionedTextDocumentIdentifier
 import com.monkopedia.lsp.ksrpc.LifecycleState
@@ -74,8 +78,11 @@ import kotlinx.serialization.json.JsonNull
  *   [Forwarder] as the subprocess's client.
  * - Requests are **delegated** to the subprocess stub. Diagnostic ranges coming back are
  *   translated from WRAPPED-`.kt` space down to csgs space (Phase 3 / #38) via
- *   [DiagnosticTranslation]; completion/hover positions stay in wrapped space (Phase 4 /
- *   #39).
+ *   [DiagnosticTranslation]. Completion/hover/signatureHelp (Phase 4 / #39) are
+ *   request/response: the cursor [com.monkopedia.lsp.Position] is translated UP (csgs →
+ *   wrapped) on the way in, and any range in the response (completion `textEdit`, hover
+ *   `range`) is translated back DOWN to csgs space on the way out — same
+ *   [DiagnosticTranslation] header-line offset, so they cannot drift.
  *
  * **Pull→push diagnostics bridge.** kotlin-lsp does NOT proactively push
  * `publishDiagnostics`; it answers PULL `textDocument/diagnostic`. kodemirror's editor
@@ -281,24 +288,69 @@ class BridgeLanguageServer(
         }
     }
 
+    /**
+     * Completion (Phase 4 / #39). The editor sends a cursor [Position] in **csgs** space;
+     * translate it UP to wrapped-`.kt` space (`ktLine = csgsLine + headerLines`) and
+     * retarget the document at the wrapped file before delegating. Completion items can
+     * carry a `textEdit`/`insertReplaceEdit` whose range is in wrapped-`.kt` space; on the
+     * way back, translate every such range DOWN to csgs space (the same Phase 3 mapping the
+     * diagnostics use) so the editor applies the edit on the right line.
+     */
     override suspend fun textDocumentCompletion(
         params: CompletionParams
     ): TextDocumentCompletionResult {
         val server = delegate ?: return super.textDocumentCompletion(params)
-        return server.textDocumentCompletion(params.onWrappedDocument())
+        val result = server.textDocumentCompletion(
+            params.copy(
+                textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri),
+                position = DiagnosticTranslation.toWrappedPosition(params.position)
+            )
+        )
+        return translateCompletionResult(result)
     }
 
+    /**
+     * Resolve (lazy completion detail). The resolved item may now carry a `textEdit` range
+     * (it is often omitted from the initial list and filled in on resolve); translate it
+     * back to csgs space too.
+     */
+    override suspend fun completionItemResolve(params: CompletionItem): CompletionItem {
+        val server = delegate ?: return super.completionItemResolve(params)
+        return translateCompletionItem(server.completionItemResolve(params))
+    }
+
+    /**
+     * Hover (Phase 4 / #39). Translate the request cursor UP to wrapped space; translate the
+     * response's optional [Hover.range] back DOWN to csgs space so the highlight lands on
+     * the user's line. [Hover.contents] is opaque markup with no positions, so it passes
+     * through untouched.
+     */
     override suspend fun textDocumentHover(params: HoverParams): Hover {
         val server = delegate ?: return super.textDocumentHover(params)
-        return server.textDocumentHover(
-            params.copy(textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri))
+        val hover = server.textDocumentHover(
+            params.copy(
+                textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri),
+                position = DiagnosticTranslation.toWrappedPosition(params.position)
+            )
         )
+        val range = hover.range?.let {
+            DiagnosticTranslation.translateRange(it, lspWorkspace.csgsLineCount())
+        }
+        return hover.copy(range = range)
     }
 
+    /**
+     * SignatureHelp (Phase 4 / #39). Translate the request cursor UP to wrapped space. The
+     * response ([SignatureHelp]: signatures, parameter offsets, active indices) carries no
+     * document positions, so it passes through unchanged.
+     */
     override suspend fun textDocumentSignatureHelp(params: SignatureHelpParams): SignatureHelp {
         val server = delegate ?: return super.textDocumentSignatureHelp(params)
         return server.textDocumentSignatureHelp(
-            params.copy(textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri))
+            params.copy(
+                textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri),
+                position = DiagnosticTranslation.toWrappedPosition(params.position)
+            )
         )
     }
 
@@ -328,8 +380,63 @@ class BridgeLanguageServer(
     private fun translateDiagnostics(diagnostics: List<Diagnostic>): List<Diagnostic> =
         DiagnosticTranslation.translateDiagnostics(diagnostics, lspWorkspace.csgsLineCount())
 
-    private fun CompletionParams.onWrappedDocument(): CompletionParams =
-        copy(textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri))
+    /**
+     * Translate every wrapped-`.kt` range carried by a completion result DOWN to csgs
+     * space. The result is one of two ksrpc variants: a bare array of [CompletionItem] or a
+     * [CompletionList]; both reach the items the same way. Items whose edit range maps into
+     * the header/footer are kept but their edit is dropped (no synthetic-line edit ever
+     * reaches the editor) — the editor falls back to plain-text insertion.
+     */
+    private fun translateCompletionResult(
+        result: TextDocumentCompletionResult
+    ): TextDocumentCompletionResult = when (result) {
+        is TextDocumentCompletionResult.CompletionItemArray ->
+            TextDocumentCompletionResult.CompletionItemArray(
+                result.value.map { translateCompletionItem(it) }
+            )
+        is TextDocumentCompletionResult.CompletionListValue ->
+            TextDocumentCompletionResult.CompletionListValue(
+                result.value.copy(items = result.value.items.map { translateCompletionItem(it) })
+            )
+    }
+
+    /**
+     * Translate a single completion item's edit ranges from wrapped-`.kt` to csgs space:
+     * the primary [CompletionItem.textEdit] (a `TextEdit` with a `range`, or an
+     * `InsertReplaceEdit` with `insert`+`replace` ranges) and any [additionalTextEdits].
+     * An edit that can't be mapped back (header/footer) is dropped rather than misplaced.
+     */
+    private fun translateCompletionItem(item: CompletionItem): CompletionItem {
+        val csgsLineCount = lspWorkspace.csgsLineCount()
+        val textEdit = item.textEdit?.let { translateCompletionEdit(it, csgsLineCount) }
+        val additional = item.additionalTextEdits?.mapNotNull { edit ->
+            DiagnosticTranslation.translateRange(edit.range, csgsLineCount)
+                ?.let { edit.copy(range = it) }
+        }
+        return item.copy(textEdit = textEdit, additionalTextEdits = additional)
+    }
+
+    /**
+     * Translate the union [CompletionItemTextEdit] (`TextEdit` | `InsertReplaceEdit`) back
+     * to csgs space, returning null (drop the edit) when a range falls in the header/footer.
+     */
+    private fun translateCompletionEdit(
+        edit: CompletionItemTextEdit,
+        csgsLineCount: Int
+    ): CompletionItemTextEdit? = when (edit) {
+        is TextEdit ->
+            DiagnosticTranslation.translateRange(edit.range, csgsLineCount)
+                ?.let { edit.copy(range = it) }
+        is InsertReplaceEdit -> {
+            val insert = DiagnosticTranslation.translateRange(edit.insert, csgsLineCount)
+            val replace = DiagnosticTranslation.translateRange(edit.replace, csgsLineCount)
+            if (insert != null && replace != null) {
+                edit.copy(insert = insert, replace = replace)
+            } else {
+                null
+            }
+        }
+    }
 
     private companion object {
         private const val WARMUP_ATTEMPTS = 30

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -33,9 +33,9 @@ import com.monkopedia.lsp.DocumentDiagnosticReport
 import com.monkopedia.lsp.Hover
 import com.monkopedia.lsp.HoverParams
 import com.monkopedia.lsp.InitializeParams
-import com.monkopedia.lsp.InsertReplaceEdit
 import com.monkopedia.lsp.InitializeResult
 import com.monkopedia.lsp.InitializedParams
+import com.monkopedia.lsp.InsertReplaceEdit
 import com.monkopedia.lsp.KsrpcLanguageClient
 import com.monkopedia.lsp.KsrpcLanguageServer
 import com.monkopedia.lsp.LSPAny
@@ -394,6 +394,7 @@ class BridgeLanguageServer(
             TextDocumentCompletionResult.CompletionItemArray(
                 result.value.map { translateCompletionItem(it) }
             )
+
         is TextDocumentCompletionResult.CompletionListValue ->
             TextDocumentCompletionResult.CompletionListValue(
                 result.value.copy(items = result.value.items.map { translateCompletionItem(it) })
@@ -427,6 +428,7 @@ class BridgeLanguageServer(
         is TextEdit ->
             DiagnosticTranslation.translateRange(edit.range, csgsLineCount)
                 ?.let { edit.copy(range = it) }
+
         is InsertReplaceEdit -> {
             val insert = DiagnosticTranslation.translateRange(edit.insert, csgsLineCount)
             val replace = DiagnosticTranslation.translateRange(edit.replace, csgsLineCount)

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslation.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslation.kt
@@ -56,6 +56,26 @@ object DiagnosticTranslation {
     val headerLines: Int = KcsgScript.HEADER.split("\n").size
 
     /**
+     * Translate a csgs-space [Position] (editor space, zero-based) UP to wrapped-`.kt`
+     * space — the **inverse** of [translatePosition], used for LSP **request** positions
+     * (completion/hover/signatureHelp cursors; Phase 4 / #39):
+     *
+     * ```
+     * ktLine = csgsLine + headerLines
+     * ```
+     *
+     * Columns are unchanged (the header adds whole lines at column 0). The cursor always
+     * lives inside the user's content, so — unlike the engine→editor direction — nothing
+     * is dropped: every csgs position maps to a real wrapped line. This is the SAME
+     * [headerLines] source of truth the engine→editor mapping uses, just added instead of
+     * subtracted, so the two directions can never drift apart.
+     */
+    fun toWrappedPosition(position: Position): Position {
+        val ktLine = position.line.toInt() + headerLines
+        return Position(line = ktLine.toUInt(), character = position.character)
+    }
+
+    /**
      * Translate a single engine [Position] (wrapped-`.kt`, zero-based) to csgs space, or
      * return `null` if it falls in the header or in/after the footer.
      *

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
@@ -349,6 +349,7 @@ class BridgeLanguageServerIntegrationTest {
     private fun completionLabels(result: TextDocumentCompletionResult): List<String> =
         when (result) {
             is TextDocumentCompletionResult.CompletionItemArray -> result.value.map { it.label }
+
             is TextDocumentCompletionResult.CompletionListValue ->
                 result.value.items.map { it.label }
         }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
@@ -19,11 +19,16 @@ import com.monkopedia.konstructor.PathController
 import com.monkopedia.konstructor.lsp.BridgeLanguageServer
 import com.monkopedia.konstructor.testutil.TestEnvironment
 import com.monkopedia.lsp.ClientCapabilities
+import com.monkopedia.lsp.CompletionParams
 import com.monkopedia.lsp.DefaultLanguageClient
 import com.monkopedia.lsp.DidOpenTextDocumentParams
+import com.monkopedia.lsp.HoverParams
 import com.monkopedia.lsp.InitializeParams
 import com.monkopedia.lsp.InitializedParams
+import com.monkopedia.lsp.Position
 import com.monkopedia.lsp.PublishDiagnosticsParams
+import com.monkopedia.lsp.TextDocumentCompletionResult
+import com.monkopedia.lsp.TextDocumentIdentifier
 import com.monkopedia.lsp.TextDocumentItem
 import java.io.File
 import kotlin.test.assertTrue
@@ -178,6 +183,175 @@ class BridgeLanguageServerIntegrationTest {
                 "got line ${unresolved.range.start.line.toInt()}"
         )
     }
+
+    /**
+     * A valid csgs whose body sits in the `KcsgScript` receiver scope, so the engine offers
+     * the DSL members there (e.g. `cube`, `export`). csgs line index 1 is `val c = cu` — a
+     * partial reference we request completion on (the cursor sits right after `cu`).
+     */
+    private val completionScript = """
+        val ok by primitive { cube { dimensions = xyz(1.0, 1.0, 1.0) } }
+        export("ok")
+    """.trimIndent()
+
+    /**
+     * Phase 4 (#39) request-position translation, end-to-end against the real engine.
+     * Completion at a csgs cursor inside the receiver scope must offer kcsg DSL members
+     * (here `cube`). Proves the cursor Position is translated csgs → wrapped before the
+     * engine sees it (otherwise the engine would complete in the header/wrong scope).
+     */
+    @Test
+    fun realEngineOffersKcsgCompletion() = runBlocking {
+        val config = env!!.config
+        val workspaceId = "0"
+        val konstructionId = "0"
+        val paths: PathController.Paths = PathController(config)[workspaceId, konstructionId]
+        paths.contentFile.writeText(completionScript)
+        val frontendUri = "file:///$workspaceId/$konstructionId/content.csgs"
+
+        val bridge = BridgeLanguageServer(
+            config,
+            workspaceId,
+            konstructionId,
+            object : DefaultLanguageClient() {}
+        )
+        bridge.initialize(
+            InitializeParams(
+                capabilities = ClientCapabilities(),
+                processId = ProcessHandle.current().pid().toInt(),
+                rootUri = "file:///$workspaceId"
+            )
+        )
+        bridge.initialized(InitializedParams())
+        bridge.textDocumentDidOpen(
+            DidOpenTextDocumentParams(
+                textDocument = TextDocumentItem(
+                    uri = frontendUri,
+                    languageId = "kotlin",
+                    version = 1,
+                    text = completionScript
+                )
+            )
+        )
+
+        // Request completion at the END of csgs line 0 (after `... } }`), inside the
+        // KcsgScript receiver scope. The cursor is in CSGS space; the bridge must add the
+        // header to reach the right wrapped-.kt line. Poll while the index warms.
+        val cursor = Position(
+            line = 0u,
+            character = completionScript.lines().first().length.toUInt()
+        )
+        val labels = withTimeoutOrNull(180_000) {
+            while (true) {
+                val result = runCatching {
+                    bridge.textDocumentCompletion(
+                        CompletionParams(
+                            textDocument = TextDocumentIdentifier(uri = frontendUri),
+                            position = cursor
+                        )
+                    )
+                }.getOrNull()
+                val items = result?.let { completionLabels(it) } ?: emptyList()
+                if (items.any { it == "cube" }) return@withTimeoutOrNull items
+                delay(2000)
+            }
+            @Suppress("UNREACHABLE_CODE")
+            emptyList<String>()
+        }
+
+        bridge.shutdown()
+        bridge.exit()
+
+        assertTrue(labels != null, "no completion ever returned `cube` within budget")
+        System.err.println("REAL-ENGINE completion offered ${labels.size} items")
+        assertTrue(
+            labels.contains("cube"),
+            "expected the kcsg DSL member `cube` in the receiver scope; got: " +
+                labels.take(40).joinToString(", ")
+        )
+    }
+
+    /**
+     * Phase 4 (#39) hover: hovering a kcsg symbol must resolve to non-empty content, and any
+     * returned range must already be in CSGS space (line < the header offset would mean the
+     * response range wasn't translated back down).
+     */
+    @Test
+    fun realEngineResolvesKcsgHover() = runBlocking {
+        val config = env!!.config
+        val workspaceId = "0"
+        val konstructionId = "0"
+        val paths: PathController.Paths = PathController(config)[workspaceId, konstructionId]
+        paths.contentFile.writeText(completionScript)
+        val frontendUri = "file:///$workspaceId/$konstructionId/content.csgs"
+
+        val bridge = BridgeLanguageServer(
+            config,
+            workspaceId,
+            konstructionId,
+            object : DefaultLanguageClient() {}
+        )
+        bridge.initialize(
+            InitializeParams(
+                capabilities = ClientCapabilities(),
+                processId = ProcessHandle.current().pid().toInt(),
+                rootUri = "file:///$workspaceId"
+            )
+        )
+        bridge.initialized(InitializedParams())
+        bridge.textDocumentDidOpen(
+            DidOpenTextDocumentParams(
+                textDocument = TextDocumentItem(
+                    uri = frontendUri,
+                    languageId = "kotlin",
+                    version = 1,
+                    text = completionScript
+                )
+            )
+        )
+
+        // Hover over the `cube` token on csgs line 0 (its index in the first line).
+        val cubeColumn = completionScript.lines().first().indexOf("cube") + 1
+        val cursor = Position(line = 0u, character = cubeColumn.toUInt())
+        val hover = withTimeoutOrNull(180_000) {
+            while (true) {
+                val h = runCatching {
+                    bridge.textDocumentHover(
+                        HoverParams(
+                            textDocument = TextDocumentIdentifier(uri = frontendUri),
+                            position = cursor
+                        )
+                    )
+                }.getOrNull()
+                if (h != null && h.contents.toString().length > 2) return@withTimeoutOrNull h
+                delay(2000)
+            }
+            @Suppress("UNREACHABLE_CODE")
+            null
+        }
+
+        bridge.shutdown()
+        bridge.exit()
+
+        assertTrue(hover != null, "hover never resolved kcsg content within budget")
+        System.err.println("REAL-ENGINE hover range: ${hover.range}")
+        val range = hover.range
+        // If the engine returned a range it must be translated to csgs space: the `cube`
+        // token is on csgs line 0, so the range must NOT sit at header line N.
+        if (range != null) {
+            assertTrue(
+                range.start.line.toInt() == 0,
+                "hover range must be translated to csgs space (line 0), got ${range.start.line}"
+            )
+        }
+    }
+
+    private fun completionLabels(result: TextDocumentCompletionResult): List<String> =
+        when (result) {
+            is TextDocumentCompletionResult.CompletionItemArray -> result.value.map { it.label }
+            is TextDocumentCompletionResult.CompletionListValue ->
+                result.value.items.map { it.label }
+        }
 
     private companion object {
         /** The `val broken = thisSymbolDoesNotExist123` line in [deliberateErrorScript]. */

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslationTest.kt
@@ -195,6 +195,50 @@ class DiagnosticTranslationTest {
     }
 
     @Test
+    fun `toWrappedPosition adds the header to the line and keeps the column`() {
+        // Phase 4 (#39) request direction: csgs cursor -> wrapped-.kt cursor.
+        val wrapped = DiagnosticTranslation.toWrappedPosition(pos(line = 0, character = 5))
+        assertEquals(headerLines.toUInt(), wrapped.line, "first csgs line maps to first user kt line")
+        assertEquals(5u, wrapped.character, "columns are unchanged across the wrap")
+
+        val wrapped2 = DiagnosticTranslation.toWrappedPosition(pos(line = 4, character = 12))
+        assertEquals((4 + headerLines).toUInt(), wrapped2.line)
+        assertEquals(12u, wrapped2.character)
+    }
+
+    @Test
+    fun `request-then-response position round-trips back to the same csgs position`() {
+        // The Phase 4 request mapping (toWrappedPosition) and the Phase 3 response mapping
+        // (translatePosition) are exact inverses for any in-content cursor. An off-by-N in
+        // either direction silently targets the wrong line for completion/hover.
+        val csgsLineCount = 10
+        for (csgsLine in 0 until csgsLineCount) {
+            val original = pos(line = csgsLine, character = csgsLine + 1)
+            val wrapped = DiagnosticTranslation.toWrappedPosition(original)
+            // The engine reports it on (csgsLine + headerLines).
+            assertEquals((csgsLine + headerLines).toUInt(), wrapped.line)
+            val back = DiagnosticTranslation.translatePosition(wrapped, csgsLineCount)
+            assertNotNull(back, "an in-content cursor must survive the round-trip")
+            assertEquals(original.line, back.line, "round-trip must preserve the csgs line")
+            assertEquals(original.character, back.character, "round-trip must preserve the column")
+        }
+    }
+
+    @Test
+    fun `toWrappedPosition boundary lines map to the exact user kt lines`() {
+        // First user csgs line -> first wrapped user line (== headerLines).
+        assertEquals(
+            headerLines.toUInt(),
+            DiagnosticTranslation.toWrappedPosition(pos(line = 0)).line
+        )
+        // Last user csgs line of a 3-line doc -> headerLines + 2.
+        assertEquals(
+            (headerLines + 2).toUInt(),
+            DiagnosticTranslation.toWrappedPosition(pos(line = 2)).line
+        )
+    }
+
+    @Test
     fun `translateDiagnostics drops header and footer entries but keeps user ones`() {
         val csgsLineCount = 2
         val all = listOf(

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/DiagnosticTranslationTest.kt
@@ -198,7 +198,11 @@ class DiagnosticTranslationTest {
     fun `toWrappedPosition adds the header to the line and keeps the column`() {
         // Phase 4 (#39) request direction: csgs cursor -> wrapped-.kt cursor.
         val wrapped = DiagnosticTranslation.toWrappedPosition(pos(line = 0, character = 5))
-        assertEquals(headerLines.toUInt(), wrapped.line, "first csgs line maps to first user kt line")
+        assertEquals(
+            headerLines.toUInt(),
+            wrapped.line,
+            "first csgs line maps to first user kt line"
+        )
         assertEquals(5u, wrapped.character, "columns are unchanged across the wrap")
 
         val wrapped2 = DiagnosticTranslation.toWrappedPosition(pos(line = 4, character = 12))


### PR DESCRIPTION
## Summary
`Fixes #39` (part of the LSP epic #35). Wires kcsg-DSL-aware **completion, hover, and signatureHelp** through the bridge, building on Phase 2 (engine bridge) + Phase 3 (position translation). Flag-gated (`lspEnabled` default off); flag-off behavior unchanged.

## Core: request/response position translation
These are request/response (unlike diagnostics, which are one-way), so positions cross the csgs↔wrapped-`.kt` boundary in both directions:
- **Request positions (editor → engine):** `DiagnosticTranslation.toWrappedPosition` — the inverse of Phase 3's mapping: `ktLine = csgsLine + headerLines`, reusing the SAME `KcsgScript.HEADER.split("\n").size` source of truth (no duplicated constant). Columns unchanged.
- **Response ranges (engine → editor):** translated back to csgs space via the existing Phase-3 logic, dropping/clamping header/footer-region positions like diagnostics.
- `BridgeLanguageServer` overrides the completion/hover/signatureHelp methods: translate request position in → delegate to the kotlin-lsp subprocess stub → translate response ranges out. Capabilities passed through. Diagnostics path (Phase 3) and the blind-poll delivery model (#43) untouched.

## Tests
- `DiagnosticTranslationTest` gains position round-trip cases (csgs→kt→csgs, boundaries).
- The local-only (CI-skipped) `BridgeLanguageServerIntegrationTest` asserts completion offers kcsg members and hover resolves a kcsg symbol against the **real engine**.

## Verification
- **Flag-OFF / CI-equivalent — green:** `clean test` + full `:e2e:test -Pe2e` (flag off) + `:frontend:spotlessKotlinCheck`, all pass. (Engine path not CI-tested — no binary on CI.)

Part of #35; Fixes #39