### PR TITLE
LSP #43: event-driven pull diagnostics (refresh + previousResultId + unchanged)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -29,7 +29,6 @@ import com.monkopedia.lsp.DidChangeTextDocumentParams
 import com.monkopedia.lsp.DidCloseTextDocumentParams
 import com.monkopedia.lsp.DidOpenTextDocumentParams
 import com.monkopedia.lsp.DocumentDiagnosticParams
-import com.monkopedia.lsp.DocumentDiagnosticReport
 import com.monkopedia.lsp.Hover
 import com.monkopedia.lsp.HoverParams
 import com.monkopedia.lsp.InitializeParams
@@ -41,7 +40,7 @@ import com.monkopedia.lsp.KsrpcLanguageServer
 import com.monkopedia.lsp.LSPAny
 import com.monkopedia.lsp.PublishDiagnosticsParams
 import com.monkopedia.lsp.RegistrationParams
-import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
+import com.monkopedia.lsp.ServerCapabilities
 import com.monkopedia.lsp.SignatureHelp
 import com.monkopedia.lsp.SignatureHelpParams
 import com.monkopedia.lsp.TextDocumentCompletionResult
@@ -52,13 +51,10 @@ import com.monkopedia.lsp.TextEdit
 import com.monkopedia.lsp.UnregistrationParams
 import com.monkopedia.lsp.VersionedTextDocumentIdentifier
 import com.monkopedia.lsp.ksrpc.LifecycleState
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonNull
 
 /**
@@ -84,13 +80,24 @@ import kotlinx.serialization.json.JsonNull
  *   `range`) is translated back DOWN to csgs space on the way out — same
  *   [DiagnosticTranslation] header-line offset, so they cannot drift.
  *
- * **Pull→push diagnostics bridge.** kotlin-lsp does NOT proactively push
- * `publishDiagnostics`; it answers PULL `textDocument/diagnostic`. kodemirror's editor
- * client, however, listens for PUSHED diagnostics (the Phase 1 design). So on
- * didOpen/didChange the bridge polls the engine via pull and forwards the resulting
- * items up to the editor as `publishDiagnostics` (with retry, since the cold index can
- * take ~120s to settle). If kotlin-lsp ever also pushes, the [Forwarder] forwards those
- * too — they coexist.
+ * **Event-driven pull→push diagnostics bridge (#43).** kotlin-lsp does NOT proactively
+ * push `publishDiagnostics`; it is a LSP 3.17 PULL-mode server (answers
+ * `textDocument/diagnostic`, signals "re-pull" via `workspace/diagnostic/refresh`).
+ * kodemirror's editor client, however, listens for PUSHED diagnostics (the Phase 1
+ * design). The bridge therefore turns pulls into pushes — but EVENT-DRIVEN, not by blind
+ * polling. The machinery lives in [PullDiagnosticsPublisher]:
+ *  - Pull-mode is detected authoritatively from the subprocess
+ *    [InitializeResult]'s [ServerCapabilities.diagnosticProvider] (non-null ⇒ pull mode;
+ *    there is no push capability flag). The publisher is only created when pull-mode.
+ *  - Pulls are triggered on didOpen + debounced didChange, and on the engine's
+ *    `workspace/diagnostic/refresh` — overridden on the backend [Forwarder] (the
+ *    `DefaultLanguageClient` base THROWS for it; the frontend client's is a harmless
+ *    no-op, a different object) to re-pull every open doc. A bounded cold-index backoff
+ *    covers only the FIRST pull before the index warms.
+ *  - `previousResultId` is threaded per doc; an `unchanged` report does not republish
+ *    (only a `full` report emits `publishDiagnostics`).
+ *
+ * If kotlin-lsp ever also pushes, the [Forwarder] forwards those too — they coexist.
  *
  * Lifecycle gating (required, per the lsp-kotlin maintainer): we drive [LifecycleState]
  * by hand — [initialized]/[shutdown]/[exit] advance it, and the forwarder
@@ -118,8 +125,13 @@ class BridgeLanguageServer(
     /** The subprocess-facing stub; null when the engine is unavailable. */
     private var delegate: KsrpcLanguageServer? = null
 
-    /** The in-flight diagnostics poll, cancelled/replaced on each didOpen. */
-    private var diagnosticsPoll: Job? = null
+    /**
+     * The event-driven pull→push publisher (#43). Non-null ONLY when the subprocess
+     * advertised pull-mode ([ServerCapabilities.diagnosticProvider] != null); otherwise we
+     * run no pull machinery at all. Created in [initialize] once we have the engine's
+     * capabilities.
+     */
+    private var diagnostics: PullDiagnosticsPublisher? = null
 
     /**
      * The frontend's document URI (`...content.csgs`), captured on the editor's first
@@ -158,6 +170,19 @@ class BridgeLanguageServer(
 
         override suspend fun clientUnregisterCapability(params: UnregistrationParams): Nothing? =
             null
+
+        /**
+         * ⚠️ The engine's `workspace/diagnostic/refresh` ("results may have changed,
+         * re-pull"). The [DefaultLanguageClient] base THROWS `NotImplementedError` here
+         * (the lsp-kotlin maintainer's flagged trap — distinct from the frontend client's
+         * harmless no-op). Override it to re-pull every open doc via the publisher: this is
+         * the cold-index-warmed case and the steady-state event that makes diagnostics
+         * event-driven instead of a poll loop.
+         */
+        override suspend fun workspaceDiagnosticRefresh(): Nothing? {
+            diagnostics?.onRefresh()
+            return null
+        }
     }
 
     override suspend fun initialize(params: InitializeParams): InitializeResult {
@@ -172,13 +197,55 @@ class BridgeLanguageServer(
         }
         // Drive the subprocess through the same handshake, but rooted at the synthesized
         // workspace so it loads our workspace.json + classpath.
-        return server.initialize(
+        val result = server.initialize(
             params.copy(
                 rootUri = lspWorkspace.rootUri,
                 workspaceFolders = null
             )
         )
+        // Detect pull-mode authoritatively (#43): a non-null diagnosticProvider in the
+        // engine's capabilities is the only signal (there is no push capability flag). Only
+        // then do we stand up the event-driven pull→push publisher; otherwise no pull
+        // machinery runs at all.
+        diagnostics = PullDiagnosticsPublisher.pullProviderOf(result.capabilities)
+            ?.let { provider -> createPublisher(server, provider) }
+        return result
     }
+
+    /**
+     * Build the [PullDiagnosticsPublisher] wired to THIS bridge's subprocess [server] and
+     * frontend client. The publisher owns the pull/refresh/previousResultId/debounce/backoff
+     * logic; the bridge supplies only the three seams:
+     *  - the PULL (subprocess `textDocument/diagnostic`, threading `previousResultId`),
+     *  - the PUBLISH (translate ranges to csgs space + rewrite the URI, then push up), and
+     *  - the readiness gate (the editor's `initialized` handshake).
+     */
+    private fun createPublisher(
+        server: KsrpcLanguageServer,
+        provider: com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider
+    ): PullDiagnosticsPublisher = PullDiagnosticsPublisher(
+        scope = scope,
+        diagnosticProvider = provider,
+        pull = { _, previousResultId ->
+            server.textDocumentDiagnostic(
+                DocumentDiagnosticParams(
+                    textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri),
+                    previousResultId = previousResultId
+                )
+            )
+        },
+        publish = { _, items ->
+            // Translate wrapped-.kt ranges down to csgs space, rewrite to the editor's URI.
+            val uri = frontendUri ?: lspWorkspace.documentUri
+            frontendClient.textDocumentPublishDiagnostics(
+                PublishDiagnosticsParams(
+                    uri = uri,
+                    diagnostics = translateDiagnostics(items)
+                )
+            )
+        },
+        awaitReady = { lifecycle.awaitInitialized() }
+    )
 
     override suspend fun initialized(params: InitializedParams) {
         delegate?.let { runCatching { it.initialized(params) } }
@@ -204,50 +271,9 @@ class BridgeLanguageServer(
                 )
             )
         )
-        startDiagnosticsPoll(server)
-    }
-
-    /**
-     * Poll the engine via pull `textDocument/diagnostic` and push each result up to the
-     * editor as `publishDiagnostics`. Bridges kotlin-lsp's pull-only diagnostics to the
-     * editor client's push expectation. Retries (the cold index can take ~120s to
-     * settle), then keeps refreshing at a slower cadence so later edits/analysis updates
-     * still reach the editor. Gated on `initialized` before the first push.
-     */
-    private fun startDiagnosticsPoll(server: KsrpcLanguageServer) {
-        diagnosticsPoll?.cancel()
-        diagnosticsPoll = scope.launch {
-            lifecycle.awaitInitialized()
-            var attempt = 0
-            while (true) {
-                val items = runCatching { pullDiagnostics(server) }
-                    .onFailure { hauler.error("pull diagnostics failed", it) }
-                    .getOrNull()
-                if (items != null) {
-                    val uri = frontendUri ?: lspWorkspace.documentUri
-                    // Translate wrapped-.kt ranges down to csgs space before pushing up.
-                    val translated = translateDiagnostics(items)
-                    runCatching {
-                        frontendClient.textDocumentPublishDiagnostics(
-                            PublishDiagnosticsParams(uri = uri, diagnostics = translated)
-                        )
-                    }.onFailure { hauler.error("publish diagnostics to editor failed", it) }
-                }
-                // Faster while warming up, then a slow steady-state refresh.
-                attempt++
-                delay(if (attempt < WARMUP_ATTEMPTS) WARMUP_INTERVAL else STEADY_INTERVAL)
-            }
-        }
-    }
-
-    private suspend fun pullDiagnostics(server: KsrpcLanguageServer): List<Diagnostic> {
-        val report: DocumentDiagnosticReport = server.textDocumentDiagnostic(
-            DocumentDiagnosticParams(
-                textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri)
-            )
-        )
-        // Only a FULL report carries items; an UNCHANGED report means "no new items".
-        return (report as? RelatedFullDocumentDiagnosticReport)?.items ?: emptyList()
+        // Event-driven (#43): pull now (with cold-index backoff for this first pull only),
+        // then rely on didChange/refresh. Routes by the frontend's csgs URI.
+        diagnostics?.onOpen(params.textDocument.uri)
     }
 
     override suspend fun textDocumentDidChange(params: DidChangeTextDocumentParams) {
@@ -273,12 +299,13 @@ class BridgeLanguageServer(
                 )
             )
         }.onFailure { hauler.error("Failed forwarding didChange to engine", it) }
-        // Refresh diagnostics for the new content (re-poll; same path as didOpen).
-        startDiagnosticsPoll(server)
+        // Event-driven (#43): debounced re-pull for the new content (coalesces edit bursts).
+        diagnostics?.onChange(params.textDocument.uri)
     }
 
     override suspend fun textDocumentDidClose(params: DidCloseTextDocumentParams) {
         val server = delegate ?: return
+        frontendUri?.let { diagnostics?.onClose(it) }
         runCatching {
             server.textDocumentDidClose(
                 DidCloseTextDocumentParams(
@@ -361,7 +388,7 @@ class BridgeLanguageServer(
 
     override suspend fun exit() {
         lifecycle.advanceTo(LifecycleState.Phase.EXITED)
-        diagnosticsPoll?.cancel()
+        diagnostics = null
         scope.coroutineContext[Job]?.cancel()
         delegate?.let { server ->
             runCatching { server.exit() }
@@ -438,11 +465,5 @@ class BridgeLanguageServer(
                 null
             }
         }
-    }
-
-    private companion object {
-        private const val WARMUP_ATTEMPTS = 30
-        private val WARMUP_INTERVAL = 4.seconds
-        private val STEADY_INTERVAL = 15.seconds
     }
 }

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisher.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisher.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.lsp
+
+import com.monkopedia.hauler.error
+import com.monkopedia.hauler.hauler
+import com.monkopedia.lsp.Diagnostic
+import com.monkopedia.lsp.DiagnosticOptions
+import com.monkopedia.lsp.DiagnosticRegistrationOptions
+import com.monkopedia.lsp.DocumentDiagnosticParams
+import com.monkopedia.lsp.DocumentDiagnosticReport
+import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
+import com.monkopedia.lsp.RelatedUnchangedDocumentDiagnosticReport
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * The event-driven **pull→push diagnostics bridge** for LSP #43 (epic #35).
+ *
+ * kotlin-lsp is a LSP 3.17 **pull-mode** server: it does not proactively push
+ * `publishDiagnostics`; it answers PULL `textDocument/diagnostic`, and signals "results
+ * may have changed, re-pull" out of band via `workspace/diagnostic/refresh`. kodemirror's
+ * editor client, by contrast, is **push-only** (consumes pushed `publishDiagnostics`). So
+ * the bridge must turn pulls into pushes — but *event-driven*, not by blind polling
+ * through the cold index (the Phase 2 stop-gap this class replaces).
+ *
+ * This unit is deliberately factored as a **cohesive, transport-agnostic publisher** so it
+ * can later be lifted into `lsp-ksrpc` as a reusable `DiagnosticBridge`/
+ * `PullDiagnosticsPublisher` (the lsp-kotlin maintainer offered to review it for that). It
+ * is given only:
+ *  - [pull]: how to PULL a [DocumentDiagnosticReport] for a doc (the subprocess stub's
+ *    `textDocumentDiagnostic`, with `previousResultId`),
+ *  - [publish]: how to PUSH a doc's diagnostics up to the target client (the bridge wires
+ *    this to translate ranges to csgs space + rewrite the URI, then call
+ *    `textDocumentPublishDiagnostics`),
+ *  - [awaitReady]: a gate suspended on until the target client is ready to receive (the
+ *    `initialized` handshake), and
+ *  - timing knobs ([debounce], cold-index [backoff]).
+ *
+ * It tracks per-doc [previousResultId][DocumentDiagnosticParams.previousResultId] (see
+ * [resultIds]); on each pull it threads the last id, and when the server answers an
+ * **`unchanged`** report ([RelatedUnchangedDocumentDiagnosticReport], `kind == "unchanged"`)
+ * it does **not** republish — only a **`full`** report ([RelatedFullDocumentDiagnosticReport],
+ * `kind == "full"`) emits a `publishDiagnostics`. This kills redundant upward pushes.
+ *
+ * Triggers:
+ *  - [onOpen] — pull immediately (the doc just opened); bounded cold-index backoff applies
+ *    to this FIRST pull only, since the index may not be warm yet (a pull can transiently
+ *    fail or come back empty before analysis settles).
+ *  - [onChange] — debounced pull for that doc (coalesces a burst of edits/saves).
+ *  - [onRefresh] — re-pull **all** open docs; this is the engine's
+ *    `workspace/diagnostic/refresh` (the cold-index-warmed case), and is the steady-state
+ *    event that makes this event-driven rather than a poll loop.
+ *
+ * Pull-mode is **gated** by the caller on [ServerCapabilities.diagnosticProvider] being
+ * non-null (there is no push capability flag, so a non-null diagnosticProvider is the
+ * authoritative pull-mode signal — see [pullProviderOf]); this class is only constructed
+ * for pull-mode servers. [interFileDependencies] is surfaced informational (editing one
+ * doc can change another's diagnostics → governs re-pull breadth), and a refresh already
+ * re-pulls every open doc, which honours it.
+ */
+internal class PullDiagnosticsPublisher(
+    private val scope: CoroutineScope,
+    /** Authoritative pull-mode capability (non-null ⇒ pull mode). Surfaced for callers. */
+    val diagnosticProvider: ServerCapabilitiesDiagnosticProvider,
+    /**
+     * Pull the diagnostic report for `uri`, threading the last-seen `previousResultId`
+     * (null on the first pull). Returns the raw report; this class interprets full vs
+     * unchanged.
+     */
+    private val pull: suspend (uri: String, previousResultId: String?) -> DocumentDiagnosticReport,
+    /** Push a `full` report's diagnostics up to the target client for a doc. */
+    private val publish: suspend (uri: String, diagnostics: List<Diagnostic>) -> Unit,
+    /** Suspends until the target client has signalled it is ready (the `initialized` gate). */
+    private val awaitReady: suspend () -> Unit,
+    private val debounce: Duration = DEFAULT_DEBOUNCE,
+    private val backoff: ColdIndexBackoff = ColdIndexBackoff()
+) {
+    private val hauler = hauler("PullDiagnosticsPublisher")
+
+    /**
+     * Whether editing one doc can change another doc's diagnostics. Informational here
+     * (an [onRefresh] already re-pulls every open doc); surfaced for callers/extraction.
+     */
+    val interFileDependencies: Boolean = when (diagnosticProvider) {
+        is DiagnosticOptions -> diagnosticProvider.interFileDependencies
+        is DiagnosticRegistrationOptions -> diagnosticProvider.interFileDependencies
+    }
+
+    /** Whether the server also answers whole-workspace `workspace/diagnostic`. Informational. */
+    val workspaceDiagnostics: Boolean = when (diagnosticProvider) {
+        is DiagnosticOptions -> diagnosticProvider.workspaceDiagnostics
+        is DiagnosticRegistrationOptions -> diagnosticProvider.workspaceDiagnostics
+    }
+
+    /** The set of docs currently open in the engine, re-pulled on a refresh. */
+    private val openDocs: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /** Per-doc last-seen result id, threaded as `previousResultId` on the next pull. */
+    private val resultIds = ConcurrentHashMap<String, String>()
+
+    /** Per-doc in-flight debounced-change job, replaced on each [onChange]. */
+    private val changeJobs = ConcurrentHashMap<String, Job>()
+
+    /** Serializes pulls for a single doc so result-id threading is race-free. */
+    private val pullLocks = ConcurrentHashMap<String, Mutex>()
+
+    private fun lockFor(uri: String): Mutex = pullLocks.getOrPut(uri) { Mutex() }
+
+    /**
+     * Register `uri` as open and pull its diagnostics now, with bounded cold-index backoff
+     * (this first pull may race the index warming). Replaces the Phase 2 unconditional
+     * retry loop: once the engine sends a refresh we're event-driven, so backoff applies
+     * ONLY to this initial pull.
+     */
+    fun onOpen(uri: String) {
+        openDocs.add(uri)
+        scope.launch {
+            awaitReady()
+            pullWithColdIndexBackoff(uri)
+        }
+    }
+
+    /**
+     * A doc changed (didChange/didSave). Debounce a re-pull for it, coalescing a burst of
+     * edits into a single pull once the user pauses.
+     */
+    fun onChange(uri: String) {
+        openDocs.add(uri)
+        changeJobs.put(
+            uri,
+            scope.launch {
+                awaitReady()
+                delay(debounce)
+                pullOnce(uri)
+            }
+        )?.cancel()
+    }
+
+    /** A doc closed: forget its result id / open state / pending change pull. */
+    fun onClose(uri: String) {
+        openDocs.remove(uri)
+        resultIds.remove(uri)
+        changeJobs.remove(uri)?.cancel()
+    }
+
+    /**
+     * The engine signalled `workspace/diagnostic/refresh` ("results may have changed,
+     * re-pull"). Re-pull EVERY open doc — this is the cold-index-warmed event and the
+     * steady-state driver of the event-driven model. Honours [interFileDependencies] by
+     * re-pulling breadth (all open docs), not just one.
+     */
+    fun onRefresh() {
+        scope.launch {
+            awaitReady()
+            for (uri in openDocs.toList()) {
+                pullOnce(uri)
+            }
+        }
+    }
+
+    /**
+     * Pull once for `uri`, threading `previousResultId` and republishing ONLY on a `full`
+     * report (an `unchanged` report means "no change since `previousResultId`" → skip the
+     * redundant push). Result-id-threaded under a per-doc lock so concurrent triggers don't
+     * interleave a stale id.
+     */
+    private suspend fun pullOnce(uri: String): PullOutcome = lockFor(uri).withLock {
+        val previousResultId = resultIds[uri]
+        val report = runCatching { pull(uri, previousResultId) }
+            .onFailure { hauler.error("pull diagnostics failed for $uri", it) }
+            .getOrElse { return@withLock PullOutcome.FAILED }
+        when (report) {
+            is RelatedFullDocumentDiagnosticReport -> {
+                report.resultId?.let { resultIds[uri] = it }
+                runCatching { publish(uri, report.items) }
+                    .onFailure { hauler.error("publish diagnostics failed for $uri", it) }
+                PullOutcome.PUBLISHED
+            }
+
+            is RelatedUnchangedDocumentDiagnosticReport -> {
+                // Unchanged since previousResultId — refresh the id but DON'T republish.
+                resultIds[uri] = report.resultId
+                PullOutcome.UNCHANGED
+            }
+        }
+    }
+
+    /**
+     * The first pull after [onOpen]: retry with bounded backoff until we either publish or
+     * exhaust attempts. The cold index can take ~120s to settle, so a pull may transiently
+     * fail or come back empty before analysis lands; once it publishes (or the doc closes)
+     * we stop and rely on event-driven [onRefresh]/[onChange].
+     */
+    private suspend fun pullWithColdIndexBackoff(uri: String) {
+        var attempt = 0
+        while (attempt < backoff.maxAttempts && uri in openDocs) {
+            val outcome = pullOnce(uri)
+            if (outcome == PullOutcome.PUBLISHED) return
+            attempt++
+            delay(backoff.interval)
+        }
+    }
+
+    private enum class PullOutcome { PUBLISHED, UNCHANGED, FAILED }
+
+    /**
+     * Bounded backoff for the FIRST pull only (before the index warms). Not a steady-state
+     * poll: after the first publish we go event-driven (refresh/change). Defaults are
+     * generous enough to cover a cold index (~120s) without an unbounded loop.
+     */
+    data class ColdIndexBackoff(
+        val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+        val interval: Duration = DEFAULT_INTERVAL
+    ) {
+        private companion object {
+            private const val DEFAULT_MAX_ATTEMPTS = 40
+            private val DEFAULT_INTERVAL = 4.seconds
+        }
+    }
+
+    companion object {
+        private val DEFAULT_DEBOUNCE = 300.milliseconds
+
+        /**
+         * The authoritative pull-mode signal: the initialize result's
+         * [ServerCapabilities.diagnosticProvider]. Non-null ⇒ pull mode (there is no push
+         * capability flag). Returns null when the server is not pull-mode (e.g. an
+         * inert/empty capabilities response), in which case the caller skips the pull
+         * machinery entirely.
+         */
+        fun pullProviderOf(
+            capabilities: ServerCapabilities?
+        ): ServerCapabilitiesDiagnosticProvider? = capabilities?.diagnosticProvider
+    }
+}

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/BridgeLanguageServerIntegrationTest.kt
@@ -185,6 +185,81 @@ class BridgeLanguageServerIntegrationTest {
     }
 
     /**
+     * Event-driven path (#43), real engine: after the FIRST diagnostic publish arrives via
+     * the didOpen pull, the bridge must NOT keep re-publishing on a timer (the old blind
+     * poll did, every 15s). With `previousResultId` + the `unchanged`-report skip, a
+     * settled doc stops emitting redundant pushes — so once diagnostics arrive, the publish
+     * count must stabilise over a further window. This is the real-engine half of the
+     * `unchanged`-dedup guard (the CI-runnable half is in [PullDiagnosticsPublisherTest]).
+     */
+    @Test
+    fun realEngineEventDrivenPullDoesNotDoublePublish() = runBlocking {
+        val config = env!!.config
+        val workspaceId = "0"
+        val konstructionId = "0"
+        val paths: PathController.Paths = PathController(config)[workspaceId, konstructionId]
+        paths.contentFile.writeText(deliberateErrorScript)
+        val frontendUri = "file:///$workspaceId/$konstructionId/content.csgs"
+
+        val firstNonEmpty = CompletableDeferred<Unit>()
+        val publishCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val frontendClient = object : DefaultLanguageClient() {
+            override suspend fun textDocumentPublishDiagnostics(params: PublishDiagnosticsParams) {
+                publishCount.incrementAndGet()
+                if (params.diagnostics.isNotEmpty() && !firstNonEmpty.isCompleted) {
+                    firstNonEmpty.complete(Unit)
+                }
+            }
+        }
+
+        val bridge = BridgeLanguageServer(config, workspaceId, konstructionId, frontendClient)
+        bridge.initialize(
+            InitializeParams(
+                capabilities = ClientCapabilities(),
+                processId = ProcessHandle.current().pid().toInt(),
+                rootUri = "file:///$workspaceId"
+            )
+        )
+        bridge.initialized(InitializedParams())
+        bridge.textDocumentDidOpen(
+            DidOpenTextDocumentParams(
+                textDocument = TextDocumentItem(
+                    uri = frontendUri,
+                    languageId = "kotlin",
+                    version = 1,
+                    text = deliberateErrorScript
+                )
+            )
+        )
+
+        val settled = withTimeoutOrNull(180_000) {
+            firstNonEmpty.await()
+            true
+        }
+        assertTrue(settled == true, "no diagnostics flowed from the engine within budget")
+
+        // Snapshot the count, then let the system sit idle: with the event-driven model the
+        // settled doc must not keep republishing on a timer. Allow at most a small grace
+        // (an in-flight backoff pull or a single engine refresh), but NOT a steady stream.
+        val afterSettle = publishCount.get()
+        delay(20_000)
+        val afterIdle = publishCount.get()
+
+        bridge.shutdown()
+        bridge.exit()
+
+        System.err.println(
+            "REAL-ENGINE publishes after settle=$afterSettle, after 20s idle=$afterIdle"
+        )
+        assertTrue(
+            afterIdle - afterSettle <= EVENT_DRIVEN_IDLE_GRACE,
+            "settled diagnostics must not re-publish on a timer; the publish count grew " +
+                "by ${afterIdle - afterSettle} over a 20s idle window " +
+                "(blind-poll regression — the unchanged-skip is not deduping)"
+        )
+    }
+
+    /**
      * A valid csgs whose body sits in the `KcsgScript` receiver scope, so the engine offers
      * the DSL members there (e.g. `cube`, `export`). csgs line index 1 is `val c = cu` — a
      * partial reference we request completion on (the cursor sits right after `cu`).
@@ -357,5 +432,12 @@ class BridgeLanguageServerIntegrationTest {
     private companion object {
         /** The `val broken = thisSymbolDoesNotExist123` line in [deliberateErrorScript]. */
         private const val EXPECTED_CSGS_ERROR_LINE = 1
+
+        /**
+         * Max extra publishes tolerated over a 20s idle window once diagnostics settle: a
+         * straggler backoff pull or a single engine-driven refresh is fine; a steady stream
+         * (the old 15s blind-poll, ~1+ per interval) is a regression.
+         */
+        private const val EVENT_DRIVEN_IDLE_GRACE = 1
     }
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisherTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisherTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.lsp
+
+import com.monkopedia.lsp.Diagnostic
+import com.monkopedia.lsp.DiagnosticOptions
+import com.monkopedia.lsp.DocumentDiagnosticReport
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
+import com.monkopedia.lsp.RelatedUnchangedDocumentDiagnosticReport
+import com.monkopedia.lsp.ServerCapabilities
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit guards for the event-driven pull→push diagnostics model (#43), exercised on the
+ * extraction-ready [PullDiagnosticsPublisher] directly (no engine, no transport): the
+ * machinery is given fake pull/publish seams and driven through the trigger surface.
+ *
+ * Covers the four behaviours the maintainer review pins down:
+ *  - **Pull-mode detection gating** — only a non-null `diagnosticProvider` is pull mode.
+ *  - **`unchanged`-report skip** — an unchanged report must NOT republish.
+ *  - **`previousResultId` threading** — the last `resultId` is fed to the next pull.
+ *  - **refresh → re-pull** — `onRefresh` re-pulls every open doc.
+ */
+class PullDiagnosticsPublisherTest {
+
+    private val uri = "file:///0/0/content.csgs"
+
+    private fun fullReport(resultId: String?, vararg messages: String): DocumentDiagnosticReport =
+        RelatedFullDocumentDiagnosticReport(
+            kind = "full",
+            resultId = resultId,
+            items = messages.map { diag(it) }
+        )
+
+    private fun unchangedReport(resultId: String): DocumentDiagnosticReport =
+        RelatedUnchangedDocumentDiagnosticReport(kind = "unchanged", resultId = resultId)
+
+    private fun diag(message: String): Diagnostic = Diagnostic(
+        range = Range(start = Position(0u, 0u), end = Position(0u, 0u)),
+        message = message
+    )
+
+    private val noBackoff = PullDiagnosticsPublisher.ColdIndexBackoff(maxAttempts = 1)
+
+    /** A pull/publish recorder driving the publisher with scripted reports. */
+    private class Recorder {
+        val pullCalls = CopyOnWriteArrayList<String?>()
+        val publishes = CopyOnWriteArrayList<List<Diagnostic>>()
+        var reports: () -> DocumentDiagnosticReport = { error("no report scripted") }
+    }
+
+    // --- pull-mode detection gating ---------------------------------------------------
+
+    @Test
+    fun `pull mode is detected only when diagnosticProvider is present`() {
+        val pullMode = ServerCapabilities(
+            diagnosticProvider = DiagnosticOptions(
+                interFileDependencies = true,
+                workspaceDiagnostics = false
+            )
+        )
+        assertNotNull(
+            PullDiagnosticsPublisher.pullProviderOf(pullMode),
+            "a non-null diagnosticProvider must be reported as pull mode"
+        )
+        assertNull(
+            PullDiagnosticsPublisher.pullProviderOf(ServerCapabilities()),
+            "no diagnosticProvider ⇒ not pull mode (the bridge runs no pull machinery)"
+        )
+        assertNull(
+            PullDiagnosticsPublisher.pullProviderOf(null),
+            "absent capabilities ⇒ not pull mode"
+        )
+    }
+
+    @Test
+    fun `provider sub-flags are surfaced for re-pull breadth decisions`() = runTest {
+        val rec = Recorder()
+        val publisher = newPublisher(
+            rec,
+            provider = DiagnosticOptions(
+                interFileDependencies = true,
+                workspaceDiagnostics = true
+            )
+        )
+        assertTrue(publisher.interFileDependencies)
+        assertTrue(publisher.workspaceDiagnostics)
+    }
+
+    // --- previousResultId threading ---------------------------------------------------
+
+    @Test
+    fun `onOpen pulls with no previousResultId and threads the returned resultId`() = runTest {
+        val rec = Recorder()
+        rec.reports = { fullReport(resultId = "rid-1", "boom") }
+        val publisher = newPublisher(rec)
+
+        publisher.onOpen(uri)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf<String?>(null), rec.pullCalls, "first pull carries no previousResultId")
+        assertEquals(1, rec.publishes.size, "a full report must publish")
+
+        // A subsequent change-triggered pull must thread the resultId from the first report.
+        publisher.onChange(uri)
+        testScheduler.advanceUntilIdle()
+        assertEquals(
+            listOf<String?>(null, "rid-1"),
+            rec.pullCalls,
+            "the next pull must thread the previous resultId"
+        )
+    }
+
+    // --- unchanged-report skip --------------------------------------------------------
+
+    @Test
+    fun `an unchanged report does not republish but still advances the resultId`() = runTest {
+        val rec = Recorder()
+        // First pull: full (rid-1, publishes). Second pull: unchanged (rid-2, no publish).
+        val scripted = ArrayDeque(
+            listOf(
+                fullReport(resultId = "rid-1", "boom"),
+                unchangedReport(resultId = "rid-2")
+            )
+        )
+        rec.reports = { scripted.removeFirst() }
+        val publisher = newPublisher(rec)
+
+        publisher.onOpen(uri)
+        testScheduler.advanceUntilIdle()
+        assertEquals(1, rec.publishes.size, "full report publishes once")
+
+        publisher.onChange(uri)
+        testScheduler.advanceUntilIdle()
+        assertEquals(
+            1,
+            rec.publishes.size,
+            "an unchanged report must NOT add a redundant publish"
+        )
+        // And the third pull threads rid-2 (the unchanged report's resultId).
+        rec.reports = { unchangedReport(resultId = "rid-3") }
+        publisher.onChange(uri)
+        testScheduler.advanceUntilIdle()
+        assertEquals(
+            listOf<String?>(null, "rid-1", "rid-2"),
+            rec.pullCalls,
+            "the unchanged report's resultId must thread forward"
+        )
+    }
+
+    // --- refresh → re-pull ------------------------------------------------------------
+
+    @Test
+    fun `onRefresh re-pulls every open doc`() = runTest {
+        val rec = Recorder()
+        rec.reports = { fullReport(resultId = "rid", "boom") }
+        val publisher = newPublisher(rec)
+
+        publisher.onOpen(uri)
+        testScheduler.advanceUntilIdle()
+        val afterOpen = rec.pullCalls.size
+
+        publisher.onRefresh()
+        testScheduler.advanceUntilIdle()
+        assertEquals(
+            afterOpen + 1,
+            rec.pullCalls.size,
+            "refresh must re-pull the open doc"
+        )
+        assertTrue(rec.publishes.size >= 2, "refresh republished the full report")
+    }
+
+    @Test
+    fun `onClose stops the doc being re-pulled on refresh`() = runTest {
+        val rec = Recorder()
+        rec.reports = { fullReport(resultId = "rid", "boom") }
+        val publisher = newPublisher(rec)
+
+        publisher.onOpen(uri)
+        testScheduler.advanceUntilIdle()
+        val afterOpen = rec.pullCalls.size
+
+        publisher.onClose(uri)
+        publisher.onRefresh()
+        testScheduler.advanceUntilIdle()
+        assertEquals(
+            afterOpen,
+            rec.pullCalls.size,
+            "a closed doc must not be re-pulled on refresh"
+        )
+    }
+
+    private fun kotlinx.coroutines.CoroutineScope.newPublisher(
+        rec: Recorder,
+        provider: com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider = DiagnosticOptions(
+            interFileDependencies = false,
+            workspaceDiagnostics = false
+        )
+    ): PullDiagnosticsPublisher = PullDiagnosticsPublisher(
+        scope = this,
+        diagnosticProvider = provider,
+        pull = { _, previousResultId ->
+            rec.pullCalls.add(previousResultId)
+            rec.reports()
+        },
+        publish = { _, diagnostics -> rec.publishes.add(diagnostics) },
+        awaitReady = { },
+        backoff = noBackoff
+    )
+}


### PR DESCRIPTION
Part of #35; Fixes #43.

Replaces the Phase 2 **blind-poll** diagnostics path with the **event-driven pull model** the lsp-kotlin maintainer specified (two maintainer reviews captured in #43). Flag-gated throughout (`lspEnabled` default OFF + `Config.isKotlinLspAvailable`): flag-off ⇒ no behavioural change.

## The event-driven model
- **Pull-mode detection (authoritative).** After init, read the subprocess `InitializeResult`'s `ServerCapabilities.diagnosticProvider`. Non-null ⇒ pull mode (there is no push capability flag). The pull machinery is created **only** when pull-mode; otherwise nothing runs. Sub-flags `interFileDependencies` / `workspaceDiagnostics` are surfaced (informational; a refresh already re-pulls every open doc, honouring inter-file breadth).
- **Backend-forwarder `workspaceDiagnosticRefresh()` override.** ⚠️ Our backend `DefaultLanguageClient` subclass (the one talking to the subprocess) THROWS `NotImplementedError` for this unless overridden — the maintainer's flagged trap (the kodemirror frontend client's version is a harmless no-op, a different object). Overridden to **re-pull every open doc** on the engine's `workspace/diagnostic/refresh` ("results may have changed, re-pull") — exactly the cold-index-warmed case, and the steady-state driver that makes this event-driven instead of a poll loop.
- **Triggers:** didOpen (immediate, with bounded cold-index backoff for the FIRST pull only), debounced didChange, and refresh. The unconditional retry/steady-poll loop is gone.
- **`previousResultId` + `unchanged` dedup.** Per-doc `resultId` is threaded into each `DocumentDiagnosticParams.previousResultId`; an `unchanged` report (`RelatedUnchangedDocumentDiagnosticReport`, `kind=="unchanged"`) does **not** republish — only a `full` report emits `publishDiagnostics`. Kills redundant upward pushes.
- Phase 3 position translation is intact: diagnostic ranges still translate to csgs space before publishing.

## Shaped for extraction
The pull/refresh/`previousResultId`/debounce/cold-index-backoff logic is factored into a cohesive, transport-agnostic **`PullDiagnosticsPublisher`** (kept `internal` to konstructor — no new public API). Given `(pull seam, publish seam, readiness gate, debounce, backoff)` it tracks per-doc resultId, pulls on trigger/refresh, emits on `full`/skips `unchanged`. `BridgeLanguageServer` supplies only the three seams (pull = subprocess `textDocument/diagnostic`; publish = translate-to-csgs + URI-rewrite + push; gate = `initialized`). Clean boundaries for the maintainer's later lift into lsp-ksrpc as a reusable `DiagnosticBridge`.

## Verification
- **Flag-OFF / CI-equivalent — green:** compiles; full clean `:e2e:test` green flag-off (incl. `LspPipeTest`, 0 failures/0 errors across suites); all-module `./gradlew spotlessCheck` green; `./gradlew test` green.
- **Unit tests** (`PullDiagnosticsPublisherTest`, CI-runnable): pull-mode detection gating, `unchanged`-report skip, `previousResultId` threading, refresh→re-pull, close.
- **Real engine (LOCAL ONLY — not CI; CI has no binary):** `KONSTRUCTOR_KOTLIN_LSP` → `intellij-server`. The deliberate unresolved-reference error still arrives via the event-driven path (didOpen pull + refresh), translated to csgs line 1; and a settled doc does **not** double-publish (`publishes after settle=1, after 20s idle=1` — the old 15s blind-poll would have grown the count). Engine path is not CI-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
