### PR TITLE
Add a Settings toggle for LSP (code completion & errors)

### DIFF
--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/BaseE2eTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/BaseE2eTest.kt
@@ -23,6 +23,7 @@ import java.io.File
 import java.nio.file.Paths
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
@@ -117,6 +118,12 @@ abstract class BaseE2eTest {
     protected fun bridgeStateInt(field: String): Int {
         val state = bridgeState()
         return state[field]?.jsonPrimitive?.int ?: -1
+    }
+
+    /** Return a single boolean field from bridge state. */
+    protected fun bridgeStateBoolean(field: String): Boolean {
+        val state = bridgeState()
+        return state[field]?.jsonPrimitive?.boolean ?: false
     }
 
     /** Return a list-of-string field from bridge state. */

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ThemeAndKeymapTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ThemeAndKeymapTest.kt
@@ -133,6 +133,25 @@ class ThemeAndKeymapTest : BaseE2eTest() {
     }
 
     @Test
+    fun testLspEnabledToggle() {
+        setupWorkspaceWithCode()
+
+        // Default is opt-out: LSP off, so the editor is unchanged for users who
+        // never enable it.
+        assertEquals(false, bridgeStateBoolean("lspEnabled"))
+
+        // The Settings switch (and its bridge action) flips the persisted flag;
+        // the snapshot reflects it so the toggle shows the right state.
+        bridgeAction("setLspEnabled", "true")
+        page.waitForTimeout(3000.0)
+        assertEquals(true, bridgeStateBoolean("lspEnabled"))
+
+        bridgeAction("setLspEnabled", "false")
+        page.waitForTimeout(3000.0)
+        assertEquals(false, bridgeStateBoolean("lspEnabled"))
+    }
+
+    @Test
     fun testSettingsPaneShowsDropdowns() {
         setupWorkspaceWithCode()
 

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/BridgeStateSnapshot.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/BridgeStateSnapshot.kt
@@ -47,6 +47,7 @@ data class AppStateSnapshot(
     val codePaneMode: String = "EDITOR",
     val editorTheme: String = "DRACULA",
     val keymap: String = "VIM",
+    val lspEnabled: Boolean = false,
     val screen: String = "loading",
     val konstructionCount: Int = 0,
     val konstructionNames: List<String> = emptyList(),

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
@@ -334,6 +334,9 @@ object JsBridge {
         scope.launch {
             settingsVm.keymap.collect { refreshTrigger.value++ }
         }
+        scope.launch {
+            settingsVm.lspEnabled.collect { refreshTrigger.value++ }
+        }
         if (konstructionVm != null) {
             scope.launch {
                 konstructionVm.targetDisplays.collect { refreshTrigger.value++ }
@@ -441,6 +444,7 @@ object JsBridge {
             codePaneMode = settingsVm.codePaneMode.value.name,
             editorTheme = settingsVm.editorTheme.value.name,
             keymap = settingsVm.keymap.value.name,
+            lspEnabled = settingsVm.lspEnabled.value,
             screen = when {
                 workspaces == null -> "loading"
                 workspaces.isEmpty() -> "empty"

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/settings/SettingsPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/settings/SettingsPane.kt
@@ -51,6 +51,7 @@ fun SettingsPane(modifier: Modifier = Modifier) {
     val editorTheme by settingsVm.editorTheme.collectAsState()
     val keymap by settingsVm.keymap.collectAsState()
     val vimDisplayLineMotion by settingsVm.vimDisplayLineMotion.collectAsState()
+    val lspEnabled by settingsVm.lspEnabled.collectAsState()
 
     Column(
         modifier = modifier.padding(16.dp),
@@ -90,6 +91,15 @@ fun SettingsPane(modifier: Modifier = Modifier) {
                 onCheckedChange = { settingsVm.setVimDisplayLineMotion(it) }
             )
         }
+
+        // Code intelligence via the kotlin-lsp language server: completion,
+        // hover, signature help, and live error diagnostics in the editor.
+        // Opt-in; requires the server to have an LSP engine configured.
+        SettingSwitchRow(
+            label = "Code completion & errors (LSP)",
+            checked = lspEnabled,
+            onCheckedChange = { settingsVm.setLspEnabled(it) }
+        )
 
         SettingSwitchRow(
             label = "Show code on left",


### PR DESCRIPTION
## What
Adds a visible **"Code completion & errors (LSP)"** switch to the Settings pane, wired to `SettingsViewModel.setLspEnabled`.

## Why
The LSP feature (epic #35) shipped opt-in (`lspEnabled` default off), but the only way to flip it was the TestBridge console action — there was no user-facing control, so the opt-in was unreachable from the UI. (Discovered when trying to actually turn LSP on.)

## Changes
- `SettingsPane.kt` — a `SettingSwitchRow` in the editor-settings group, same idiom as the existing theme/keymap/display toggles.
- `BridgeStateSnapshot.kt` + `JsBridge.kt` — surface `lspEnabled` in the `AppStateSnapshot` (+ a refresh collector), consistent with `editorTheme`/`keymap` already being observable; lets the switch reflect persisted state and makes the flag e2e-observable.
- `BaseE2eTest.kt` — `bridgeStateBoolean` helper.
- `ThemeAndKeymapTest.kt` — `testLspEnabledToggle`: default-off → on → off round-trip via the snapshot.

## Verification
- Full `clean :e2e:test -Pe2e` GREEN (incl. the new test) + `spotlessCheck` all modules — locally, 5m53s. The flag-on path is inert without an engine, so the test is CI-runnable.

No behavior change when the switch is off (still byte-for-byte the prior editor). Closes the go-live UX gap for the LSP feature (#35).