### PR TITLE
Implement KcsgHost.stlVersion to fix stl() import cache staleness (#11)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/hostservices/ScriptHostImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/hostservices/ScriptHostImpl.kt
@@ -59,6 +59,25 @@ class ScriptHostImpl(
         return controller.paths.contentFile.absolutePath
     }
 
+    /**
+     * Version token for the SOURCE STL konstruction (issue #11): its content file's
+     * `lastModified:length`. This is the original STL content — the file [findStl] returns
+     * and that [KcsgRemoteHostImpl][com.monkopedia.konstructor.lib.KcsgRemoteHostImpl] then
+     * COPIES per resolve — so it changes only when the source konstruction is actually
+     * edited, not on every build (the copy's mtime would over-invalidate). Null when
+     * [stlName] doesn't resolve to an STL konstruction.
+     */
+    override suspend fun stlVersion(stlName: String): String? {
+        val target = findTarget(stlName)?.takeIf { it.type == STL } ?: return null
+        val controller = KonstructorManager(config).controllerFor(target)
+        val contentFile = controller.paths.contentFile
+        return if (contentFile.exists()) {
+            "${contentFile.lastModified()}:${contentFile.length()}"
+        } else {
+            null
+        }
+    }
+
     override suspend fun storeCached(hash: String): String {
         val target = File(cacheDir, "$hash.stl")
         return target.absolutePath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 logback = "1.5.18"
 clikt = "5.0.3"
 hauler = "0.4.0"
-kcsg = "0.4.2"
+kcsg = "0.4.3"
 ksrpc = "1.1.1"
 koin = "4.2.0"
 ktor = "3.4.2"

--- a/lib/src/main/kotlin/com/monkopedia/konstructor/lib/HostService.kt
+++ b/lib/src/main/kotlin/com/monkopedia/konstructor/lib/HostService.kt
@@ -30,6 +30,16 @@ interface HostService : RpcHostService {
     @KsMethod("/get_stl")
     suspend fun findStl(stlName: String): String?
 
+    /**
+     * An opaque token that changes whenever the **source** STL konstruction named
+     * [stlName] changes, folded into kcsg's `stl()` import cache key (issue #11). Null
+     * when [stlName] doesn't resolve to an STL konstruction. Must be derived from the
+     * SOURCE konstruction's content — NOT the path returned by [findStl], which the host
+     * copies on every resolve, so its mtime would change every build and over-invalidate.
+     */
+    @KsMethod("/stl_version")
+    suspend fun stlVersion(stlName: String): String?
+
     @KsMethod("/store_cached")
     suspend fun storeCached(hash: String): String
 

--- a/lib/src/main/kotlin/com/monkopedia/konstructor/lib/KcsgRemoteHostImpl.kt
+++ b/lib/src/main/kotlin/com/monkopedia/konstructor/lib/KcsgRemoteHostImpl.kt
@@ -63,6 +63,10 @@ internal class KcsgRemoteHostImpl(
         return Path(stlLocation.absolutePath)
     }
 
+    override fun stlVersion(stlName: String): String = dispatchThread.blockForSuspension {
+        hostService.stlVersion(stlName)
+    } ?: ""
+
     override fun storeCached(hash: String, csg: CSG) {
         val path = dispatchThread.blockForSuspension {
             hostService.storeCached(hash)


### PR DESCRIPTION
Fixes #11.

kcsg 0.4.3 (now on Maven Central) ships the opt-in `KcsgHost.stlVersion(stlName)` hook that folds an opaque token into the `stl()` import cache key. Without it, a konstruction that imports another via `stl(...)` does **not** rebuild when the source STL konstruction changes — the import goes stale (~6 `stl()`-importing konstructions affected).

### Changes
- Bump kcsg `0.4.2` → `0.4.3`.
- Add `stlVersion(stlName)` to the RPC `HostService` interface.
- Implement it in `ScriptHostImpl` (backend): the **source** STL konstruction's content-file `lastModified:length`.
- Override `KcsgHost.stlVersion` in `KcsgRemoteHostImpl`, bridging to the RPC host (defaulting to `""`).

### Key correctness point (per the issue)
The token uses the **source konstruction's content file**, NOT the path `findStl` returns. `KcsgRemoteHostImpl.findStl` does `copyTo(stlLocation)` on every resolve, so that copy's mtime changes each build and would *over*-invalidate (stl() imports would never cache). The source content file changes only when the source konstruction is actually edited — the stable, correct signal.

### Verification
`:lib:build` + `:backend:compileKotlinJvm` + `spotlessCheck` all green. The override compiling confirms kcsg 0.4.3's `KcsgHost` declares `stlVersion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
