### PR TITLE
Remove unused WorkspaceViewModel.createKonstruction/deleteKonstruction

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/WorkspaceViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/WorkspaceViewModel.kt
@@ -66,32 +66,6 @@ class WorkspaceViewModel(private val serviceHolder: ServiceHolder) : ViewModel()
         }
     }
 
-    suspend fun createKonstruction(name: String, workspaceId: String): Konstruction? {
-        val ws = currentWorkspace ?: return null
-        return try {
-            val k = ws.create(
-                Konstruction(
-                    name = name,
-                    workspaceId = workspaceId,
-                    id = ""
-                )
-            )
-            refreshKonstructions()
-            k
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    suspend fun deleteKonstruction(konstruction: Konstruction) {
-        val ws = currentWorkspace ?: return
-        try {
-            ws.delete(konstruction)
-            refreshKonstructions()
-        } catch (_: Exception) {
-        }
-    }
-
     suspend fun renameWorkspace(name: String) {
         val ws = currentWorkspace ?: return
         try {


### PR DESCRIPTION
Removes `WorkspaceViewModel.createKonstruction(name, workspaceId)` and `WorkspaceViewModel.deleteKonstruction(konstruction)`, which had no callers.

A repo-wide grep confirms production konstruction CRUD goes through `NavigationDialogViewModel.createKonstruction` / `.deleteKonstruction` (wired from `CreateKonstructionDialog` / `EditKonstructionDialog`), and the e2e `JsBridge` re-implements the same calls inline against the service. `WorkspaceViewModel` is otherwise used only for read-state plus `loadWorkspace` / `refreshKonstructions` / `selectKonstruction` / `renameWorkspace`.

The `Konstruction` import is retained because it is still referenced by the `_konstructions` StateFlow.

Verification:
- `:frontend:compileKotlinWasmJs` — BUILD SUCCESSFUL (only pre-existing warnings)
- `:frontend:spotlessCheck` — BUILD SUCCESSFUL

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)