### PR TITLE
Remove unused TargetDisplayRepository.clear(); mark sync-conflict detection pending (#26)

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
@@ -357,6 +357,13 @@ class KonstructionViewModel(
 
         override suspend fun onContentChange(u: Unit) {
             try {
+                // TODO(#3, migration regression #5): sync-conflict detection.
+                // This silently overwrites local edits when the server copy
+                // diverges. When dirty local content is present it should
+                // instead raise NavigationDialogViewModel.showSyncConflictDialog()
+                // (SyncConflictDialog / MainScreen are already wired for this;
+                // only the detection here is missing). See the @Ignore'd e2e test
+                // MigrationRegressionTest.syncConflictDialogFiresOnConcurrentEdit.
                 _content.value = ks.fetch()
             } catch (_: Exception) {
             }

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/TargetDisplayRepository.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/TargetDisplayRepository.kt
@@ -65,12 +65,6 @@ class TargetDisplayRepository(
         _displays.value = load(key)
     }
 
-    /** Clear state when no konstruction is active. */
-    fun clear() {
-        currentKey = null
-        _displays.value = emptyMap()
-    }
-
     /**
      * Reconcile the stored displays with the authoritative list of target
      * names. Adds entries for new targets (with defaults), removes entries


### PR DESCRIPTION
Fixes #26.

Two items from the Compose-migration dead-code sweep. I split them because they turned out to be different situations:

### 1. `TargetDisplayRepository.clear()` — removed (option a)
Zero callers. Konstruction switches call `activate(...)` instead, and every other `.clear()` in the tree is on a collection. Genuinely dead, no tracked plan referencing it. Removed.

### 2. Sync-conflict dialog path — kept, TODO added (option b)
The issue proposed removing `showSyncConflictDialog()` + `showSyncConflict` + `SyncConflictDialog` + the `MainScreen` branch as an unreachable feature. I confirmed `showSyncConflictDialog()` has no callers, so the dialog is indeed never triggered today.

However, this is **not** speculative over-engineering — it's the completed half of a *tracked, regressed* feature:
- Issue #3 lists it as **migration regression #5** ("Definitely broken"): pre-migration the app detected the conflict and prompted the user (Overwrite / Discard); post-migration `onContentChange` silently overwrites local edits.
- There is an `@Ignore`d e2e regression test, `MigrationRegressionTest.syncConflictDialogFiresOnConcurrentEdit`, explicitly written to be un-ignored once detection is re-wired.

Removing the dialog would delete the done half of a test-covered regression and orphan that e2e test. The issue itself offers option (b) for exactly this case: leave a one-line TODO at the detection site so the missing piece reads as pending rather than silently dead. I added a `TODO(#3, ...)` at the detection site (`KonstructionViewModel.onContentChange`) pointing at the dialog and the ignored test, and kept the dialog wiring.

If you'd prefer full removal anyway (accepting the loss of the wired UI + retiring the e2e test), say so and I'll follow up.

### Verification
- `./gradlew :frontend:compileKotlinWasmJs` — BUILD SUCCESSFUL
- `./gradlew :frontend:spotlessCheck` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)