### PR TITLE
e2e: factor duplicated wait-for-state blocks into BaseE2eTest helpers

### DIFF
--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/AppLoadTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/AppLoadTest.kt
@@ -37,12 +37,7 @@ class AppLoadTest : BaseE2eTest() {
         loadApp()
         waitForBridge()
         // Wait a moment for the service to connect and load the workspace list
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen !== 'loading'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(15000.0)
-        )
+        waitForNotLoading()
         val screen = bridgeStateString("screen")
         assertEquals("empty", screen, "Fresh server should show empty screen")
         val wsCount = bridgeStateInt("workspaceCount")

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/BaseE2eTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/BaseE2eTest.kt
@@ -101,6 +101,34 @@ abstract class BaseE2eTest {
         )
     }
 
+    /**
+     * Wait until [jsCondition] holds against the bridge state. The condition is a
+     * JS expression evaluated with `globalThis.__konstructor.state` already known to
+     * be present (this helper prepends the `state &&` guard), e.g.
+     * `"globalThis.__konstructor.state.screen === 'main'"`.
+     *
+     * Consolidates the many inline `waitForFunction(... state && <cond> ...)` blocks
+     * that used to carry a fully-qualified `Page.WaitForFunctionOptions` and a
+     * per-copy magic timeout. Tune shared waits via the timeout constants below.
+     */
+    protected fun waitForState(jsCondition: String, timeoutMs: Double = DEFAULT_STATE_TIMEOUT) {
+        page.waitForFunction(
+            "() => globalThis.__konstructor.state && ($jsCondition)",
+            null,
+            Page.WaitForFunctionOptions().setTimeout(timeoutMs)
+        )
+    }
+
+    /** Wait until the app has reached the main screen. */
+    protected fun waitForMainScreen(timeoutMs: Double = MAIN_SCREEN_TIMEOUT) {
+        waitForState("globalThis.__konstructor.state.screen === 'main'", timeoutMs)
+    }
+
+    /** Wait until the app has left the initial loading screen. */
+    protected fun waitForNotLoading(timeoutMs: Double = NOT_LOADING_TIMEOUT) {
+        waitForState("globalThis.__konstructor.state.screen !== 'loading'", timeoutMs)
+    }
+
     /** Return the current bridge state as a parsed JsonObject. */
     protected fun bridgeState(): JsonObject {
         val raw = page.evaluate("() => JSON.stringify(globalThis.__konstructor.state)")
@@ -241,4 +269,18 @@ abstract class BaseE2eTest {
     }
 
     protected fun waitOpts(timeout: Double) = Page.WaitForSelectorOptions().setTimeout(timeout)
+
+    companion object {
+        /** Default timeout for a generic [waitForState] predicate. */
+        const val DEFAULT_STATE_TIMEOUT: Double = 30000.0
+
+        /** Timeout for waiting on the app to reach the main screen. */
+        const val MAIN_SCREEN_TIMEOUT: Double = 60000.0
+
+        /** Timeout for waiting on the app to leave the loading screen. */
+        const val NOT_LOADING_TIMEOUT: Double = 15000.0
+
+        /** Timeout for a compile+build round-trip to surface results in bridge state. */
+        const val BUILD_TIMEOUT: Double = 120000.0
+    }
 }

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ErrorFooterTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ErrorFooterTest.kt
@@ -101,20 +101,13 @@ class ErrorFooterTest : BaseE2eTest() {
         waitForBridge()
         page.reload()
         waitForBridge()
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            Page.WaitForFunctionOptions().setTimeout(60000.0)
-        )
+        waitForMainScreen()
         bridgeAction("setCodePaneMode", "EDITOR")
         // Wait for the auto compile to surface diagnostics in the bridge state.
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.diagnostics && " +
+        waitForState(
+            "globalThis.__konstructor.state.diagnostics && " +
                 "globalThis.__konstructor.state.diagnostics.length >= 2",
-            null,
-            Page.WaitForFunctionOptions().setTimeout(120000.0)
+            BUILD_TIMEOUT
         )
     }
 

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/LspPipeTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/LspPipeTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package com.monkopedia.konstructor.e2e
-
-import com.microsoft.playwright.Page
 import com.monkopedia.konstructor.common.Konstruction
 import com.monkopedia.konstructor.common.Konstructor
 import com.monkopedia.ksrpc.ksrpcEnvironment
@@ -63,12 +61,9 @@ class LspPipeTest : BaseE2eTest() {
         bridgeAction("createWorkspace", "LspWs")
         // The version bump can land a beat before the workspaceIds StateFlow propagates
         // into bridge state; wait for the list to be non-empty before reading it.
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.workspaceIds && " +
-                "globalThis.__konstructor.state.workspaceIds.length >= 1",
-            null,
-            Page.WaitForFunctionOptions().setTimeout(30000.0)
+        waitForState(
+            "globalThis.__konstructor.state.workspaceIds && " +
+                "globalThis.__konstructor.state.workspaceIds.length >= 1"
         )
         val wsId = bridgeStateStringList("workspaceIds").first()
 
@@ -122,14 +117,5 @@ class LspPipeTest : BaseE2eTest() {
             "With no kotlin-lsp binary on CI the bridge is inert; expected 0 " +
                 "diagnostics, got count=$count"
         }
-    }
-
-    private fun waitForMainScreen() {
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            Page.WaitForFunctionOptions().setTimeout(60000.0)
-        )
     }
 }

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/MigrationRegressionTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/MigrationRegressionTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package com.monkopedia.konstructor.e2e
-
-import com.microsoft.playwright.Page
 import com.monkopedia.konstructor.common.Konstruction
 import com.monkopedia.konstructor.common.Konstructor
 import com.monkopedia.konstructor.common.Space
@@ -66,15 +64,6 @@ class MigrationRegressionTest : BaseE2eTest() {
         val client = HttpClient { install(WebSockets) }
         val conn = client.asWebsocketConnection("${server.baseUrl}/konstructor", env)
         conn.defaultChannel().toStub<Konstructor, String>()
-    }
-
-    private fun waitForMainScreen(timeoutMs: Double = 60000.0) {
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            Page.WaitForFunctionOptions().setTimeout(timeoutMs)
-        )
     }
 
     private fun localStorageKeys(): List<String> {

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/MigrationVisualRegressionTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/MigrationVisualRegressionTest.kt
@@ -104,12 +104,7 @@ class MigrationVisualRegressionTest : BaseE2eTest() {
     fun emptyStateMatchesBaselineShape() {
         loadApp()
         waitForBridge()
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen !== 'loading'",
-            null,
-            Page.WaitForFunctionOptions().setTimeout(20000.0)
-        )
+        waitForNotLoading(20000.0)
         page.waitForTimeout(1500.0)
         // Tolerance is loose: this guards orientation/layout, not exact pixels.
         assertBaseline("01-empty-state", maxDiffFraction = 0.60)

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/SaveFlowTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/SaveFlowTest.kt
@@ -51,12 +51,7 @@ class SaveFlowTest : BaseE2eTest() {
         page.reload()
         waitForBridge()
 
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(60000.0)
-        )
+        waitForMainScreen()
 
         // Get workspace ID
         val wsId = bridgeStateStringList("workspaceIds").first()
@@ -81,12 +76,7 @@ class SaveFlowTest : BaseE2eTest() {
         page.reload()
         waitForBridge()
 
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(60000.0)
-        )
+        waitForMainScreen()
 
         // Switch to editor
         bridgeAction("setCodePaneMode", "EDITOR")

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ScreenshotTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ScreenshotTest.kt
@@ -28,12 +28,7 @@ class ScreenshotTest : BaseE2eTest() {
         loadApp()
         waitForBridge()
         // Wait for the screen to settle
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen !== 'loading'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(15000.0)
-        )
+        waitForNotLoading()
         screenshot("01-empty-state")
     }
 
@@ -47,12 +42,7 @@ class ScreenshotTest : BaseE2eTest() {
         // Reload so Compose starts fresh with the workspace already existing
         page.reload()
         waitForBridge()
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(30000.0)
-        )
+        waitForMainScreen(DEFAULT_STATE_TIMEOUT)
         page.waitForTimeout(3000.0)
         screenshot("02-main-screen-with-workspace")
 

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/TargetControlTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/TargetControlTest.kt
@@ -70,20 +70,13 @@ class TargetControlTest : BaseE2eTest() {
         waitForBridge()
         page.reload()
         waitForBridge()
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(60000.0)
-        )
+        waitForMainScreen()
         bridgeAction("setCodePaneMode", "EDITOR")
         // Wait for compile + build to finish and target displays to populate
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.targets && " +
+        waitForState(
+            "globalThis.__konstructor.state.targets && " +
                 "globalThis.__konstructor.state.targets.length === 2",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(120000.0)
+            BUILD_TIMEOUT
         )
     }
 
@@ -166,12 +159,10 @@ class TargetControlTest : BaseE2eTest() {
         // Reload and verify settings survived
         page.reload()
         waitForBridge()
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.targets && " +
+        waitForState(
+            "globalThis.__konstructor.state.targets && " +
                 "globalThis.__konstructor.state.targets.length === 2",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(60000.0)
+            MAIN_SCREEN_TIMEOUT
         )
         val reloaded = targetSnapshot("cubeA")!!
         assertEquals(false, reloaded.getBool("isEnabled"))

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ThemeAndKeymapTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ThemeAndKeymapTest.kt
@@ -63,12 +63,7 @@ class ThemeAndKeymapTest : BaseE2eTest() {
         waitForBridge()
         page.reload()
         waitForBridge()
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.screen === 'main'",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(30000.0)
-        )
+        waitForMainScreen(DEFAULT_STATE_TIMEOUT)
         // Switch to editor and wait for content to load
         bridgeAction("setCodePaneMode", "EDITOR")
         page.waitForTimeout(5000.0)

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/WorkspaceCrudTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/WorkspaceCrudTest.kt
@@ -29,12 +29,7 @@ class WorkspaceCrudTest : BaseE2eTest() {
         bridgeAction("createWorkspace", "TestWs")
 
         // Wait for workspace list to show 1 workspace
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.workspaceCount === 1",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(30000.0)
-        )
+        waitForState("globalThis.__konstructor.state.workspaceCount === 1")
         val wsCount = bridgeStateInt("workspaceCount")
         assertEquals(1, wsCount, "Should have 1 workspace after creation")
         val names = bridgeStateStringList("workspaceNames")
@@ -49,12 +44,7 @@ class WorkspaceCrudTest : BaseE2eTest() {
         // Create a workspace first
         bridgeAction("createWorkspace", "ToDelete")
 
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.workspaceCount === 1",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(30000.0)
-        )
+        waitForState("globalThis.__konstructor.state.workspaceCount === 1")
 
         // Get the workspace id
         val ids = bridgeStateStringList("workspaceIds")
@@ -64,12 +54,7 @@ class WorkspaceCrudTest : BaseE2eTest() {
         // Delete it
         bridgeAction("deleteWorkspace", wsId)
 
-        page.waitForFunction(
-            "() => globalThis.__konstructor.state && " +
-                "globalThis.__konstructor.state.workspaceCount === 0",
-            null,
-            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(30000.0)
-        )
+        waitForState("globalThis.__konstructor.state.workspaceCount === 0")
 
         val wsCount = bridgeStateInt("workspaceCount")
         assertEquals(0, wsCount, "Should have 0 workspaces after deletion")


### PR DESCRIPTION
## Summary

Test-only refactor addressing the code-health suggestion in #27. Consolidates the many inline `page.waitForFunction(() => globalThis.__konstructor.state && <cond>, null, Page.WaitForFunctionOptions().setTimeout(...))` blocks scattered across the e2e suite into shared helpers on `BaseE2eTest`.

## Changes

- New `protected fun waitForState(jsCondition: String, timeoutMs: Double = DEFAULT_STATE_TIMEOUT)` on `BaseE2eTest` — prepends the `state &&` guard and wraps the `WaitForFunctionOptions().setTimeout` boilerplate.
- Convenience `waitForMainScreen(timeoutMs = MAIN_SCREEN_TIMEOUT)` and `waitForNotLoading(timeoutMs = NOT_LOADING_TIMEOUT)` on top of it.
- Named timeout constants in a companion object: `DEFAULT_STATE_TIMEOUT` (30s), `MAIN_SCREEN_TIMEOUT` (60s), `NOT_LOADING_TIMEOUT` (15s), `BUILD_TIMEOUT` (120s) — the magic timeouts now have a single named home.
- Replaced ~15 inline copies across `AppLoadTest`, `ErrorFooterTest`, `LspPipeTest`, `MigrationRegressionTest`, `MigrationVisualRegressionTest`, `SaveFlowTest`, `ScreenshotTest`, `TargetControlTest`, `ThemeAndKeymapTest`, `WorkspaceCrudTest`.
- Removed the two private `waitForMainScreen` helpers (`LspPipeTest`, `MigrationRegressionTest`) and the now-unused `com.microsoft.playwright.Page` imports.

## Behavior

Identical. Every call site retains its original timeout value — where a site used a non-default timeout (e.g. the two 30s main-screen waits, the 120s build waits, the 20s not-loading wait) it's passed explicitly. Timeout values themselves are unchanged; this is pure consolidation. Net -49 lines.

## Verification

- `./gradlew :e2e:compileTestKotlin` — BUILD SUCCESSFUL (only pre-existing unrelated warnings).
- `./gradlew :e2e:spotlessKotlinCheck` — BUILD SUCCESSFUL.
- Did not run the full e2e suite (needs Xvfb+GPU; slow/flaky in this environment). This is test-refactor-only with no production code touched.

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)