### PR TITLE
Collapse the 4 name dialogs into one shared NameEntryDialog (#55)

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/CreateKonstructionDialog.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/CreateKonstructionDialog.kt
@@ -15,49 +15,17 @@
  */
 package com.monkopedia.konstructor.frontend.ui.dialogs
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import com.monkopedia.konstructor.frontend.viewmodel.NavigationDialogViewModel
 import org.koin.compose.koinInject
 
 @Composable
 fun CreateKonstructionDialog(workspaceId: String) {
     val dialogVm = koinInject<NavigationDialogViewModel>()
-    var name by remember { mutableStateOf("") }
 
-    AlertDialog(
-        onDismissRequest = { dialogVm.hideCreateKonstructionDialog() },
-        title = { Text("Enter new konstruction name") },
-        text = {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Name") },
-                singleLine = true
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    if (name.isNotBlank()) {
-                        dialogVm.createKonstruction(name, workspaceId)
-                    }
-                }
-            ) {
-                Text("Set")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = { dialogVm.hideCreateKonstructionDialog() }) {
-                Text("Cancel")
-            }
-        }
+    NameEntryDialog(
+        title = "Enter new konstruction name",
+        onConfirm = { name -> dialogVm.createKonstruction(name, workspaceId) },
+        onDismiss = { dialogVm.hideCreateKonstructionDialog() }
     )
 }

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/CreateWorkspaceDialog.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/CreateWorkspaceDialog.kt
@@ -15,49 +15,17 @@
  */
 package com.monkopedia.konstructor.frontend.ui.dialogs
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import com.monkopedia.konstructor.frontend.viewmodel.NavigationDialogViewModel
 import org.koin.compose.koinInject
 
 @Composable
 fun CreateWorkspaceDialog() {
     val dialogVm = koinInject<NavigationDialogViewModel>()
-    var name by remember { mutableStateOf("") }
 
-    AlertDialog(
-        onDismissRequest = { dialogVm.hideCreateWorkspaceDialog() },
-        title = { Text("Enter new workspace name") },
-        text = {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Name") },
-                singleLine = true
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    if (name.isNotBlank()) {
-                        dialogVm.createWorkspace(name)
-                    }
-                }
-            ) {
-                Text("Set")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = { dialogVm.hideCreateWorkspaceDialog() }) {
-                Text("Cancel")
-            }
-        }
+    NameEntryDialog(
+        title = "Enter new workspace name",
+        onConfirm = { name -> dialogVm.createWorkspace(name) },
+        onDismiss = { dialogVm.hideCreateWorkspaceDialog() }
     )
 }

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/EditKonstructionDialog.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/EditKonstructionDialog.kt
@@ -15,19 +15,7 @@
  */
 package com.monkopedia.konstructor.frontend.ui.dialogs
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import com.monkopedia.konstructor.common.Konstruction
 import com.monkopedia.konstructor.frontend.viewmodel.NavigationDialogViewModel
 import org.koin.compose.koinInject
@@ -35,48 +23,19 @@ import org.koin.compose.koinInject
 @Composable
 fun EditKonstructionDialog(konstruction: Konstruction) {
     val dialogVm = koinInject<NavigationDialogViewModel>()
-    var name by remember { mutableStateOf(konstruction.name) }
 
-    AlertDialog(
-        onDismissRequest = { dialogVm.hideEditKonstructionDialog() },
-        title = { Text("Change konstruction name") },
-        text = {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Name") },
-                singleLine = true
+    NameEntryDialog(
+        title = "Change konstruction name",
+        onConfirm = { name ->
+            dialogVm.renameKonstruction(
+                konstruction.workspaceId,
+                konstruction.id,
+                name
             )
         },
-        confirmButton = {
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                TextButton(
-                    onClick = { dialogVm.deleteKonstruction(konstruction) }
-                ) {
-                    Text("Delete")
-                }
-                Row {
-                    TextButton(onClick = { dialogVm.hideEditKonstructionDialog() }) {
-                        Text("Cancel")
-                    }
-                    TextButton(
-                        onClick = {
-                            if (name.isNotBlank()) {
-                                dialogVm.renameKonstruction(
-                                    konstruction.workspaceId,
-                                    konstruction.id,
-                                    name
-                                )
-                            }
-                        }
-                    ) {
-                        Text("Save")
-                    }
-                }
-            }
-        }
+        onDismiss = { dialogVm.hideEditKonstructionDialog() },
+        initialName = konstruction.name,
+        confirmLabel = "Save",
+        onDelete = { dialogVm.deleteKonstruction(konstruction) }
     )
 }

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/EditWorkspaceDialog.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/EditWorkspaceDialog.kt
@@ -15,18 +15,7 @@
  */
 package com.monkopedia.konstructor.frontend.ui.dialogs
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import com.monkopedia.konstructor.common.Space
 import com.monkopedia.konstructor.frontend.viewmodel.NavigationDialogViewModel
 import org.koin.compose.koinInject
@@ -34,44 +23,13 @@ import org.koin.compose.koinInject
 @Composable
 fun EditWorkspaceDialog(space: Space) {
     val dialogVm = koinInject<NavigationDialogViewModel>()
-    var name by remember { mutableStateOf(space.name) }
 
-    AlertDialog(
-        onDismissRequest = { dialogVm.hideEditWorkspaceDialog() },
-        title = { Text("Change workspace name") },
-        text = {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Name") },
-                singleLine = true
-            )
-        },
-        confirmButton = {
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = androidx.compose.ui.Modifier.fillMaxWidth()
-            ) {
-                TextButton(
-                    onClick = { dialogVm.deleteWorkspace(space) }
-                ) {
-                    Text("Delete")
-                }
-                Row {
-                    TextButton(onClick = { dialogVm.hideEditWorkspaceDialog() }) {
-                        Text("Cancel")
-                    }
-                    TextButton(
-                        onClick = {
-                            if (name.isNotBlank()) {
-                                dialogVm.renameWorkspace(space.id, name)
-                            }
-                        }
-                    ) {
-                        Text("Save")
-                    }
-                }
-            }
-        }
+    NameEntryDialog(
+        title = "Change workspace name",
+        onConfirm = { name -> dialogVm.renameWorkspace(space.id, name) },
+        onDismiss = { dialogVm.hideEditWorkspaceDialog() },
+        initialName = space.name,
+        confirmLabel = "Save",
+        onDelete = { dialogVm.deleteWorkspace(space) }
     )
 }

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/NameEntryDialog.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/dialogs/NameEntryDialog.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.frontend.ui.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+/**
+ * A shared name-entry dialog used by the create/edit workspace and konstruction
+ * flows. It renders an [AlertDialog] with a single "Name" [OutlinedTextField]
+ * and a confirm action that only fires when the entered name is non-blank.
+ *
+ * When [onDelete] is non-null the confirm row also shows a "Delete" button on
+ * the leading edge (the edit variants), otherwise a standard confirm/dismiss
+ * button layout is used (the create variants).
+ *
+ * @param title dialog title text.
+ * @param onConfirm invoked with the trimmed-of-blank-check name on confirm.
+ * @param onDismiss invoked on cancel / outside-dismiss.
+ * @param initialName initial value of the text field.
+ * @param confirmLabel label of the confirm button.
+ * @param onDelete when non-null, shows a "Delete" button that invokes this.
+ */
+@Composable
+fun NameEntryDialog(
+    title: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+    initialName: String = "",
+    confirmLabel: String = "Set",
+    onDelete: (() -> Unit)? = null
+) {
+    var name by remember { mutableStateOf(initialName) }
+
+    val textField: @Composable () -> Unit = {
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Name") },
+            singleLine = true
+        )
+    }
+    val confirm: () -> Unit = {
+        if (name.isNotBlank()) {
+            onConfirm(name)
+        }
+    }
+
+    if (onDelete == null) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text(title) },
+            text = textField,
+            confirmButton = {
+                TextButton(onClick = confirm) {
+                    Text(confirmLabel)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel")
+                }
+            }
+        )
+    } else {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text(title) },
+            text = textField,
+            confirmButton = {
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    TextButton(onClick = onDelete) {
+                        Text("Delete")
+                    }
+                    Row {
+                        TextButton(onClick = onDismiss) {
+                            Text("Cancel")
+                        }
+                        TextButton(onClick = confirm) {
+                            Text(confirmLabel)
+                        }
+                    }
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
Fixes #55.

## What
Extracts one `NameEntryDialog` composable and turns the four near-identical name dialogs (`CreateWorkspaceDialog`, `CreateKonstructionDialog`, `EditWorkspaceDialog`, `EditKonstructionDialog`) into thin wrappers around it.

```kotlin
@Composable
fun NameEntryDialog(
    title: String,
    onConfirm: (String) -> Unit,
    onDismiss: () -> Unit,
    initialName: String = "",
    confirmLabel: String = "Set",
    onDelete: (() -> Unit)? = null, // shows the Delete button when non-null
)
```

- `onDelete == null` → the **create** layout: standard `confirmButton` ("Set") + `dismissButton` ("Cancel").
- `onDelete != null` → the **edit** layout: `Row(SpaceBetween)` with Delete on the leading edge and Cancel + Save (confirmLabel "Save") trailing.

## Behavior / appearance preserved exactly
- Same blank-name validation (`if (name.isNotBlank())` before the VM call).
- Same titles, button labels ("Set" for create, "Save" for edit, "Cancel", "Delete"), and the same `OutlinedTextField(label = "Name", singleLine = true)`.
- Same VM callbacks and initial values (`""` for create, `space.name` / `konstruction.name` for edit).
- `MainScreen` call sites are unchanged (the four public composables keep their signatures).
- Also removes the inline fully-qualified `androidx.compose.ui.Modifier` inconsistency in `EditWorkspaceDialog`.

Net: 5 files changed, 140 insertions, 173 deletions — ~4 files of boilerplate collapsed into one parameterized dialog.

## Verification
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :frontend:compileKotlinWasmJs` — BUILD SUCCESSFUL
- `./gradlew :frontend:spotlessCheck` — BUILD SUCCESSFUL

This is UX-adjacent; deferring to @monkopedia-reviewer for the visual signoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)