### PR TITLE
Add CachingHeaders: no-cache for un-hashed frontend bundle, long cache for wasm

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
         implementation(libs.clikt)
         implementation(libs.ktor.server.core)
         implementation(libs.ktor.server.compression)
+        implementation(libs.ktor.server.caching.headers)
         implementation(libs.ktor.server.cors)
         implementation(libs.ktor.server.websockets)
         implementation(libs.ktor.server.status.pages)

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/App.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/App.kt
@@ -27,11 +27,14 @@ import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.serialized
 import com.monkopedia.ksrpc.server.ServiceApp
+import io.ktor.http.CacheControl
+import io.ktor.http.content.CachingOptions
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.http.content.defaultResource
 import io.ktor.server.http.content.resources
 import io.ktor.server.http.content.static
+import io.ktor.server.plugins.cachingheaders.CachingHeaders
 import io.ktor.server.plugins.compression.Compression
 import io.ktor.server.plugins.compression.gzip
 import io.ktor.server.plugins.compression.matchContentType
@@ -97,6 +100,31 @@ class App : ServiceApp("konstructor") {
                 io.ktor.http.ContentType.Text.Any,
                 io.ktor.http.ContentType.Application.Json
             )
+        }
+        // Cache policy for the frontend bundle. index.html and frontend.js are NOT
+        // content-hashed, so they MUST revalidate — otherwise a browser can serve a
+        // stale frontend.js pointing at an old wasm hash after a redeploy (which
+        // manifests as bizarre input/coordinate bugs). The wasm IS content-hashed
+        // (immutable URL), so it can be cached long. Without this, Ktor sent no
+        // cache headers and Chrome heuristically cached the un-hashed frontend.js.
+        install(CachingHeaders) {
+            options { _, content ->
+                val ct = content.contentType?.withoutParameters()
+                when {
+                    ct == null -> null
+
+                    ct.match(io.ktor.http.ContentType.parse("application/wasm")) ->
+                        CachingOptions(CacheControl.MaxAge(maxAgeSeconds = 31_536_000))
+
+                    ct.match(io.ktor.http.ContentType.Text.Html) ||
+                        ct.match(io.ktor.http.ContentType.Application.JavaScript) ||
+                        // Ktor serves .js as text/javascript, not application/javascript.
+                        ct.match(io.ktor.http.ContentType.parse("text/javascript")) ->
+                        CachingOptions(CacheControl.NoCache(null))
+
+                    else -> null
+                }
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-io = { module = "io.ktor:ktor-io", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-compression = { module = "io.ktor:ktor-server-compression", version.ref = "ktor" }
+ktor-server-caching-headers = { module = "io.ktor:ktor-server-caching-headers", version.ref = "ktor" }
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 ktor-server-host-common = { module = "io.ktor:ktor-server-host-common", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }


### PR DESCRIPTION
## What
Adds a Ktor `CachingHeaders` policy for the served frontend bundle in `App.kt::configureHttp`:
- `index.html` + `frontend.js` (NOT content-hashed) → `Cache-Control: no-cache` (must-revalidate)
- `*.wasm` (content-hashed, immutable URL) → `Cache-Control: max-age=31536000`

Ktor serves `.js` as `text/javascript` (not `application/javascript`), so that content type is matched explicitly.

## Why
The frontend's `index.html`/`frontend.js` are not content-hashed and were served with **no cache headers**, so after a redeploy Chrome could serve a stale `frontend.js` pointing at an old (mismatched) wasm hash. That surfaced as bizarre input/coordinate behavior (the "every click → 0,0" phantom) during the #171 editor click-targeting investigation on adolin. Verified live on the probe deploy: `frontend.js`/`index.html` → `no-cache`, wasm → `max-age=31536000`.

## Scope
Backend-only, additive. Extracted as a standalone change from the larger `lsp-types-1.2.0` WIP branch so it can land independently. No behavior change beyond response cache headers.

## Test
`:backend:compileKotlinJvm` + `spotlessCheck` green locally (JDK 21).