### PR TITLE
CI: actually run :backend:jvmTest (lifecycle `test` skips it)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Run backend + protocol unit tests
-        run: ./gradlew test
+        run: ./gradlew test :backend:jvmTest :protocol:jvmTest
 
       - name: Run e2e tests under Xvfb
         run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' ./gradlew :e2e:test -Pe2e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew shadowJar
 ./gradlew :lib:shadowJar
 
 # Run backend/protocol unit+integration tests
-./gradlew test
+# Note: the lifecycle `test` task does NOT wire :backend:jvmTest in KMP projects;
+# both targets must be named explicitly.
+./gradlew test :backend:jvmTest :protocol:jvmTest
 
 # Run e2e tests (requires full build)
 ./gradlew :e2e:test -Pe2e

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
@@ -19,6 +19,7 @@ package com.monkopedia.konstructor
 
 import com.monkopedia.hauler.CallSign
 import com.monkopedia.hauler.debug
+import com.monkopedia.hauler.error
 import com.monkopedia.hauler.hauler
 import com.monkopedia.kcsg.KcsgScript
 import com.monkopedia.konstructor.common.KonstructionInfo
@@ -85,11 +86,13 @@ class KonstructionControllerImpl(
             // Optimistically set now, to have the info available immediately.
             infoImpl = value
             GlobalScope.launch(saveContext + callSign) {
-                contentFileLock.withLock {
-                    paths.infoFile.outputStream().use { output ->
-                        config.json.encodeToStream(value, output)
+                runCatching {
+                    contentFileLock.withLock {
+                        paths.infoFile.outputStream().use { output ->
+                            config.json.encodeToStream(value, output)
+                        }
                     }
-                }
+                }.onFailure { hauler.error("Failed to persist info for $workspaceId/$id", it) }
                 // Always set one more time after write to settle out any race conditions.
                 infoImpl = value
             }

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/logging/Writers.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/logging/Writers.kt
@@ -42,7 +42,12 @@ suspend fun Shipper.writeText(
     formatter: suspend FlowCollector<String>.(Box) -> Unit = LogFormatter
 ) {
     deliveries().streamDeliveriesPacked()
-        .onEach { event -> appendText(file, event, maxSize, formatter) }
+        .onEach { event ->
+            // Wrap in runCatching so an IOException (e.g. during test-env teardown when the
+            // log dir is deleted) does not propagate to the scope's uncaught-exception handler
+            // and contaminate other tests via the global handler.
+            runCatching { appendText(file, event, maxSize, formatter) }
+        }
         .launchIn(scope)
 }
 
@@ -83,7 +88,11 @@ suspend fun Shipper.writeBinary(
     serializer: BinaryFormat = Cbor
 ) {
     deliveries().streamDeliveriesPacked()
-        .onEach { event -> appendBinary(file, event, maxCount, serializer) }
+        .onEach { event ->
+            // Wrap in runCatching so an IOException (e.g. during test-env teardown when the
+            // log dir is deleted) does not propagate to the scope's uncaught-exception handler.
+            runCatching { appendBinary(file, event, maxCount, serializer) }
+        }
         .launchIn(scope)
 }
 

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonNull
 
@@ -461,11 +462,11 @@ class BridgeLanguageServer(
 
     /**
      * Per-konstruction cleanup. Drops the publisher, sends a best-effort `didClose` so the
-     * SHARED engine forgets this konstruction's document, then cancels the bridge scope.
-     * Deliberately does NOT `shutdown`/`exit`/`close` the subprocess-facing [delegate] stub,
-     * because that stub rides the shared keep-warm connection — closing it would kill the
-     * engine for other open konstructions and break the next reopen. Idempotent: a second
-     * pass is a no-op once [delegate] is nulled.
+     * SHARED engine forgets this konstruction's document, then cancels the bridge scope and
+     * waits for it to fully stop. Deliberately does NOT `shutdown`/`exit`/`close` the
+     * subprocess-facing [delegate] stub, because that stub rides the shared keep-warm
+     * connection — closing it would kill the engine for other open konstructions and break
+     * the next reopen. Idempotent: a second pass is a no-op once [delegate] is nulled.
      */
     private suspend fun teardown() {
         diagnostics = null
@@ -480,7 +481,10 @@ class BridgeLanguageServer(
             }
         }
         delegate = null
-        scope.coroutineContext[Job]?.cancel()
+        // cancelAndJoin: wait for all scope children (hauler writers, etc.) to actually finish
+        // before returning, so callers that free resources (e.g. the temp dir in tests) do not
+        // race with in-flight IO coroutines.
+        scope.coroutineContext[Job]?.cancelAndJoin()
     }
 
     /**


### PR DESCRIPTION
## What's broken

In a Kotlin Multiplatform project, the lifecycle `test` task does **not** wire `:backend:jvmTest`. A `--dry-run` confirms that `./gradlew test` only pulls in `:lib:test` (no-source) and `:e2e:test` — never `:backend:jvmTest`. This means the entire backend unit suite (KonstructorImplTest, ExecuteTaskTest, KonstructionControllerImplTest, all the LSP tests, etc.) has **never run in CI**. The CLAUDE.md doc also incorrectly stated `./gradlew test` was sufficient to run backend tests.

## Fix (ci.yaml)

Add `:backend:jvmTest :protocol:jvmTest` explicitly to the test step:

```
./gradlew test :backend:jvmTest :protocol:jvmTest
```

This is the minimal, explicit change. The existing `test` target is kept for `:lib` and `:e2e` (skipped without `-Pe2e`); the two JVM targets are named explicitly.

## Backend suite was RED on main — root cause + fixes included

Wiring the tests directly was blocked because `:backend:jvmTest` was **red on clean main** due to two inter-test contamination bugs. Both have been fixed in this PR so CI comes up green:

**1. `BridgeLanguageServer.teardown()` — cancel-but-no-join**

`teardown()` called `scope.cancel()` but returned immediately. Background hauler log-writer coroutines (on `Dispatchers.IO`) were still in flight when the test's `@AfterTest` deleted the temp dir, causing `FileNotFoundException` in a `GlobalScope`-parented coroutine that hit the global uncaught-exception handler. The next `runTest` call then saw `UncaughtExceptionsBeforeTest`.

Fix: change `scope.coroutineContext[Job]?.cancel()` to `?.cancelAndJoin()` so `teardown()` (which is `suspend`) waits for all scope children to finish before returning.

**2. `Writers.writeText/writeBinary` — unhandled `IOException` in `launchIn`**

The log-file flow collectors (`appendText` / `appendBinary`) were called directly inside `onEach` with no error handling. An `IOException` from a deleted log dir propagated to the `launchIn` coroutine's scope and then to the global uncaught-exception handler — same contamination vector as above, but from `KonstructorImpl`'s `GlobalScope`-based log writers.

Fix: wrap the `appendText`/`appendBinary` calls in `runCatching` in both `writeText` and `writeBinary`.

**3. `KonstructionController.info` setter — bare `GlobalScope.launch`**

The `info` setter fire-and-forgets a `GlobalScope.launch` to persist `info.json`. If the temp dir is deleted before this coroutine runs, the `FileOutputStream` throws `IOException` into `GlobalScope`, which has no exception handler → global uncaught-exception handler again.

Fix: wrap the write in `runCatching` with an `onFailure` log.

## Confirmed green

`:backend:jvmTest` confirmed green on clean `origin/main` with these fixes: **98 tests passed, 15 skipped** (integration tests behind `-Dintegration=true`).  
`:protocol:jvmTest`: **17 tests passed**.  
Exact CI command `./gradlew test :backend:jvmTest :protocol:jvmTest` also confirmed green locally.

## Test plan

- [ ] CI passes (both the new `:backend:jvmTest` + `:protocol:jvmTest` steps and the existing spotless + e2e steps)
- [ ] No integration tests are unexpectedly included (they're skipped without `-Dintegration=true`)
- [ ] CLAUDE.md now correctly documents the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)