### PR TITLE
Fix flaky KonstructionServiceListenerTest.oneSlowListenerDoesNotBlockOthers (CI timing race)

### DIFF
--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionServiceListenerTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionServiceListenerTest.kt
@@ -204,10 +204,14 @@ class KonstructionServiceListenerTest {
         awaitUntil(message = "fast listener blocked by slow listener") {
             fast.contentChanges.isNotEmpty()
         }
-        assertTrue(
-            slow.contentChanges.isNotEmpty(),
-            "slow listener should have started its callback"
-        )
+        // Poll rather than assert immediately: the slow listener records its
+        // content change before parking on the gate, but its coroutine may not
+        // have been scheduled yet when the fast listener finished (a timing race
+        // that flaked under CI load). awaitUntil still proves fan-out isn't
+        // serialized — a serialized impl would hang the fast awaitUntil above.
+        awaitUntil(message = "slow listener should have started its callback") {
+            slow.contentChanges.isNotEmpty()
+        }
 
         // Release the slow listener and clean up.
         gate.complete(Unit)


### PR DESCRIPTION
## What
`oneSlowListenerDoesNotBlockOthers` asserted `slow.contentChanges.isNotEmpty()` **immediately** after the fast listener's `awaitUntil` returned. Changed it to poll with `awaitUntil` instead.

## Why
The slow `FakeKonstructionListener` records its content change *before* parking on the gate, but its coroutine may not have been scheduled yet at the moment the fast listener finished — a scheduling race. It passes locally but flaked under CI load. It only became visible now that #69 wired `:backend:jvmTest` into CI (it had been silently un-run). Polling eliminates the race while still proving fan-out is not serialized (a serialized impl would hang the *fast* listener's `awaitUntil` above, failing first).

## Test
`:backend:jvmTest --tests "*KonstructionServiceListenerTest*"` — 5/5 consecutive `--rerun-tasks` green; spotless clean. Test-only change.