### PR TITLE
Fix: new/empty konstruction shows previous file's editor content

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/editor/EditorPane.kt
@@ -393,9 +393,13 @@ private fun EditorContent(
 
     // When content changes externally (server load, not user save), update
     // the editor document without recreating the session — preserves undo history.
+    // Must sync EMPTY content too: switching to a new/empty konstruction sets the
+    // loaded content to "", and without applying it the editor would keep showing
+    // the previously-open konstruction's text until a page refresh. The
+    // `currentDoc != content` guard already skips redundant no-op updates.
     LaunchedEffect(content) {
         val currentDoc = session.state.doc.toString()
-        if (currentDoc != content && content.isNotEmpty()) {
+        if (currentDoc != content) {
             session.dispatch(
                 com.monkopedia.kodemirror.state.TransactionSpec(
                     changes = com.monkopedia.kodemirror.state.ChangeSpec.Single(


### PR DESCRIPTION
## Bug
Creating a new workspace + new konstruction (or switching to any empty konstruction) loads the editor with the **previously-open** konstruction's content. A page refresh clears it. Reported on v0.3.0 prod.

## Root cause
`EditorPane.EditorContent` has a `LaunchedEffect(content)` that syncs externally-loaded content into the kodemirror document. Its guard was:
```kotlin
if (currentDoc != content && content.isNotEmpty()) { … replace doc … }
```
The `&& content.isNotEmpty()` means an **empty** loaded content is never applied. Sequence for a new konstruction B (after A had text "X"):
1. `selectedKonId → B`; the editor session is recreated (`remember(selectedKonId, …)`) with `doc = content` — but `content` is still "X" at that instant (the `loadKonstruction` fetch is async).
2. `loadKonstruction(B)` sets the shared content flow `"X" → ""`.
3. `LaunchedEffect(content)` fires with `content == ""` → the `isNotEmpty()` guard skips it → the doc stays "X".

Refresh works because on a fresh load the konstruction is empty from the start, so the session is created with an empty doc.

## Fix
Remove the `content.isNotEmpty()` clause (one line). Empty content now syncs into the editor. The remaining `currentDoc != content` guard still skips redundant updates, and per-konstruction session recreation still preserves undo history for non-empty loads.

## Verification
- `:frontend:compileKotlinWasmJs` + `spotlessCheck` green (JDK 21).
- Manual: open a konstruction with content, create a new konstruction → editor is now empty (previously showed the old text). Reproduces reliably before, fixed after.

## Test note (transparency)
No automated regression test in this PR: the editor renders to a WebGL canvas and its *rendered doc* is not exposed to the e2e TestBridge (the bridge only exposes the service-side `ks.fetch()` content, which was already correct — the bug is specifically the displayed doc lagging). A proper regression test needs a small bridge hook to expose the kodemirror doc (push it from the session `onUpdate`, same pattern as `cursorLine`). Happy to add that as a follow-up if preferred — flagging rather than silently shipping untested.