### PR TITLE
Clean up Kotlin 2.4.0 compiler warnings (Instant deprecation + WasmJsInterop opt-in)

### DIFF
--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -114,4 +114,9 @@ kotlin {
 
 kotlin.compilerOptions {
     freeCompilerArgs.addAll("-Xskip-prerelease-check")
+    // The entire wasmJs source set is built on JS interop (@JsFun / external
+    // declarations across threejs bindings, JsBridge, FilePicker, etc). Kotlin
+    // 2.4.0 gates that interop behind @kotlin.js.ExperimentalWasmJsInterop, so
+    // opt in module-wide rather than annotating every external declaration.
+    optIn.add("kotlin.js.ExperimentalWasmJsInterop")
 }

--- a/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/LogFormatter.kt
+++ b/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/LogFormatter.kt
@@ -16,8 +16,8 @@
 package com.monkopedia.konstructor.common
 
 import com.monkopedia.hauler.Box
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 


### PR DESCRIPTION
Mechanical warning cleanup surfaced by the Kotlin 2.4.0 migration (#48). Warnings only — no `allWarningsAsErrors`, so nothing was broken; behavior is unchanged.

## Warnings cleared

### 1. `kotlinx.datetime.Instant` → `kotlin.time.Instant` (2 warnings)
`protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/LogFormatter.kt` — swapped the `Instant` import (line 20) driving the `Instant.fromEpochMilliseconds(...)` usage (line 27).

Clean swap: kotlinx-datetime `0.8.0` treats `kotlin.time.Instant` as the canonical type and ships the `kotlin.time.Instant.toLocalDateTime(TimeZone)` extension, so the surrounding `TimeZone` / `toLocalDateTime` code is unchanged. No serialization types touched (this is a log-formatting helper), so no ksrpc/protocol ripple.

### 2. `@kotlin.js.ExperimentalWasmJsInterop` opt-in (107 warnings, 8 files)
Kotlin 2.4.0 gates JS interop (`@JsFun` / `external` declarations) behind a new experimental marker. The warning is not limited to the 3 files named in the issue — it hits the entire wasmJs interop layer: `JsBridge.kt` (9), `LoadingIndicator.kt` (1), `threejs/OrbitControls.kt` (3), `threejs/STLLoader.kt` (8), `threejs/ThreeCore.kt` (27), `threejs/ThreeHelpers.kt` (43), `threejs/ThreeJsRenderer.kt` (15), `ui/dialogs/FilePicker.kt` (1).

Rather than annotate ~107 individual declarations, I added a **module-level opt-in** in `frontend/build.gradle.kts` (`compilerOptions.optIn.add("kotlin.js.ExperimentalWasmJsInterop")`) — the option the issue explicitly sanctions. This marker is required by the foundational interop of any wasmJs module (every `external`/`@JsFun`), which is exactly the whole-module case a module-level opt-in is for; existing per-declaration `@OptIn` in this repo are narrow single-site API opt-ins (Material3, Encoding) and remain untouched.

## Warnings intentionally left (out of scope for #49)
Pre-existing, not part of this issue:
- Koin `KoinApplication(application, content)` deprecation in `KonstruktorApp.kt:40`.
- `-Xno-param-assertions` "flag not supported by this compiler" notice.
- Gradle/Compose DSL deprecations in `frontend/build.gradle.kts` (`ExperimentalWasmDsl`, `compose.components.*`, `materialIconsExtended`).

## Verification
- `:protocol:compileKotlinJvm` + `:frontend:compileProductionExecutableKotlinWasmJs` (`--rerun-tasks`): the 107 `ExperimentalWasmJsInterop` and 2 `Instant` warnings are **gone**; no new warnings/errors introduced.
- `:backend:compileKotlinJvm` + `:backend:jvmTest`: BUILD SUCCESSFUL.
- `spotlessCheck`: BUILD SUCCESSFUL.

Fixes #49