### PR TITLE
Drop :protocol's phantom jvmMain/jvmTest blocks (keeps logback out of the fat JAR)

### DIFF
--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -46,22 +46,10 @@ kotlin {
         implementation(libs.kotlinx.serialization.json)
         implementation(libs.kotlinx.coroutines.core)
     }
-    sourceSets["jvmMain"].dependencies {
-        implementation(kotlin("stdlib"))
-        implementation(kotlin("reflect"))
-        implementation(libs.slf4j.api)
-
-        implementation(libs.kotlinx.serialization.core)
-        implementation(libs.kotlinx.serialization.json)
-        implementation(libs.logback.classic)
-    }
     sourceSets["commonTest"].dependencies {
         implementation(kotlin("test"))
         implementation(libs.kotlinx.coroutines.test)
         implementation(libs.kotlinx.serialization.json)
-    }
-    sourceSets["jvmTest"].dependencies {
-        implementation(kotlin("test-junit"))
     }
 }
 


### PR DESCRIPTION
Fixes #78.

## What was wrong

`protocol/src` contains only `commonMain/` and `commonTest/` — there is no `jvmMain` or `jvmTest` source directory. Both source sets nonetheless declared full dependency blocks, and the `jvmMain` one pulled in `logback-classic`.

`implementation` deps are excluded from `apiElements` but **not** from `runtimeElements`, so logback rode protocol's JVM runtime variant into backend's `jvmRuntimeClasspath`, and from there into `backend-all.jar` (shadowJar packs exactly that configuration). `:lib` registers hauler's `SLF4JServiceProvider` via `META-INF/services`, `mergeServiceFiles()` merged both entries, and the shipped server printed on every start:

```
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [com.monkopedia.konstructor.lib.logging.HaulerServiceProvider@...]
SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@...]
```

SLF4J then picked a binding non-deterministically — and there is no `logback.xml` anywhere in the repo, so the logback branch was silently unconfigured.

## The change

Delete the two dead blocks in `protocol/build.gradle.kts` — 12 lines, no other files touched.

`backend/src/.../App.kt:46` imports `org.slf4j.LoggerFactory` and backend does not declare slf4j-api itself; it gets it transitively through hauler (`api` in commonMain), which is why nothing needs to re-declare anything. Confirmed by the build below.

I deliberately left the `kotlinx-serialization-json` line in `commonMain` alone even though #78 mentions it as a secondary cleanup — it's unrelated to the defect and `commonTest` does use Json, so it belongs in its own change if wanted.

## Verification (on the built artifact, not just the build log)

```
$ unzip -l backend-all.jar | grep -c 'ch/qos/logback'
0                                     # was 730

$ unzip -p backend-all.jar META-INF/services/org.slf4j.spi.SLF4JServiceProvider
com.monkopedia.konstructor.lib.logging.HaulerServiceProvider    # was both providers

$ unzip -l backend-all.jar | grep -c 'org/slf4j/LoggerFactory.class'
1                                     # slf4j-api still there, as needed
```

Plus a runtime smoke test of the built jar (`--http 8099`, temp `KONSTRUCTOR_HOME`): starts, serves HTTP 200, and the log contains **zero** `SLF4J(W)` lines — logs come out in hauler's format.

Gradle: `:protocol:jvmTest :backend:jvmTest shadowJar` and `spotlessCheck` all pass. `lib-all.raj` and the `web/` bundle are still present in the jar.

(`:protocol:wasmJsBrowserTest` fails on this box with "test task did not discover any tests" — a pre-existing browser/Karma config issue unrelated to this change; the JVM test tasks are what CLAUDE.md and CI run.)