### PR TITLE
LSP: tie engine-scoped work to a connection CoroutineScope (#80)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -59,10 +59,11 @@ import com.monkopedia.lsp.ksrpc.LifecycleState
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonNull
@@ -102,8 +103,8 @@ import kotlinx.serialization.json.JsonNull
  *  - Pulls are triggered on didOpen + debounced didChange, and on the engine's
  *    `workspace/diagnostic/refresh` — overridden on the backend [Forwarder] (the
  *    `DefaultLanguageClient` base THROWS for it; the frontend client's is a harmless
- *    no-op, a different object) to re-pull every open doc. A bounded cold-index backoff
- *    covers only the FIRST pull before the index warms.
+ *    no-op, a different object) to re-pull every open doc. A cold-index retry covers only
+ *    the FIRST pull before the index warms.
  *  - `previousResultId` is threaded per doc; an `unchanged` report does not republish
  *    (only a `full` report emits `publishDiagnostics`).
  *
@@ -116,14 +117,14 @@ import kotlinx.serialization.json.JsonNull
  * client-bound request from inside [initialize] (deadlock risk).
  *
  * If the subprocess is unavailable (binary unset/missing or spawn failure),
- * [delegate] is null and the bridge degrades to an inert server: [initialize] returns
+ * [connection] is null and the bridge degrades to an inert server: [initialize] returns
  * empty capabilities, notifications are dropped. The frontend is flag-gated anyway, so
  * with the flag off this class is never constructed.
  *
  * **Self-heal after an engine crash (#54).** The kotlin-lsp subprocess can crash
  * mid-session; [KotlinLspProcess] then respawns it on the next [connect][KotlinLspProcess.connect].
- * The bridge's [delegate], however, is set once in [initialize] and would keep pointing at the
- * dead stub — so every forward call fails, [guardEngine] degrades it to inert, and LSP stays
+ * The bridge's engine [connection], however, is set once in [initialize] and would keep pointing
+ * at the dead stub — so every forward call fails, [guardEngine] degrades it to inert, LSP stays
  * dark for that document until it is closed+reopened. To self-heal, a forward call that fails
  * ([guardEngine]) triggers a single-flight [reconnect]: it re-[connect][KotlinLspProcess.connect]s
  * a fresh delegate against the (respawned) subprocess, re-runs the engine handshake, and
@@ -133,6 +134,12 @@ import kotlinx.serialization.json.JsonNull
  * leaves the bridge inert, exactly as before — it never throws out to kill the shared frontend
  * connection). Deliberately minimal: no backoff/retry-limit machinery — each failing request
  * makes at most one reconnect+retry attempt, so recovery is naturally paced by request traffic.
+ *
+ * **Engine-scoped work is tied to the connection (#80).** Everything the bridge runs on behalf of
+ * one engine connection — today the [PullDiagnosticsPublisher]'s pulls — is launched in that
+ * [EngineConnection.scope]. Cancelling the scope is the single teardown for all of it, so a
+ * connection that fails or is replaced by [reconnect] stops working immediately instead of each
+ * consumer having to notice the corpse and count itself out.
  */
 open class BridgeLanguageServer(
     private val config: Config,
@@ -144,18 +151,26 @@ open class BridgeLanguageServer(
     private val hauler = hauler("BridgeLanguageServer")
     private val lifecycle = LifecycleState()
     private val lspWorkspace = KonstructionLspWorkspace(config, workspaceId, konstructionId)
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    /** The subprocess-facing stub; null when the engine is unavailable. */
-    private var delegate: KsrpcLanguageServer? = null
+    /** The live engine connection; null when the engine is unavailable. */
+    private var connection: EngineConnection? = null
 
     /**
-     * The event-driven pull→push publisher (#43). Non-null ONLY when the subprocess
-     * advertised pull-mode ([ServerCapabilities.diagnosticProvider] != null); otherwise we
-     * run no pull machinery at all. Created in [initialize] once we have the engine's
-     * capabilities.
+     * One engine connection: the subprocess-facing [server] stub, the [scope] every piece of work
+     * launched on that engine's behalf runs in, and the pull publisher fed by it. They live and die
+     * together — [reconnect] and [teardown] cancel the [scope], which stops everything the
+     * connection had in flight (#80).
      */
-    private var diagnostics: PullDiagnosticsPublisher? = null
+    private class EngineConnection(val server: KsrpcLanguageServer) {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+        /**
+         * The event-driven pull→push publisher (#43). Non-null ONLY when the engine advertised
+         * pull-mode ([ServerCapabilities.diagnosticProvider] != null); otherwise we run no pull
+         * machinery at all. Set by [handshakeEngine], which is where the capabilities land.
+         */
+        var diagnostics: PullDiagnosticsPublisher? = null
+    }
 
     /**
      * The frontend's document URI (`...content.csgs`), captured on the editor's first
@@ -195,14 +210,14 @@ open class BridgeLanguageServer(
     /**
      * Single-flight guard for [reconnect]: when the engine crashes, N concurrent forward calls all
      * fail at once; without this each would spawn its own handshake. The first to acquire performs
-     * the reconnect; the rest observe [delegate] already swapped to the fresh stub and skip.
+     * the reconnect; the rest observe [connection] already swapped to the fresh one and skip.
      */
     private val reconnectLock = Mutex()
 
     /**
      * Set once [teardown] runs, under [reconnectLock], so a concurrent [reconnect] that was queued
-     * behind teardown observes it and bails instead of resurrecting the delegate after the scope
-     * was cancelled (which would leak the fresh subprocess connection).
+     * behind teardown observes it and bails instead of resurrecting the connection after it was
+     * cancelled (which would leak the fresh subprocess connection).
      */
     private var torndown = false
 
@@ -247,7 +262,7 @@ open class BridgeLanguageServer(
          * event-driven instead of a poll loop.
          */
         override suspend fun workspaceDiagnosticRefresh(): Nothing? {
-            diagnostics?.onRefresh()
+            connection?.diagnostics?.onRefresh()
             return null
         }
     }
@@ -271,21 +286,22 @@ open class BridgeLanguageServer(
         // spawn/connect the warm subprocess. NO blocking client-bound request here.
         lspWorkspace.synthesize()
         val server = connectEngine()
-        delegate = server
         if (server == null) {
             hauler.error("kotlin-lsp engine unavailable; bridge is inert")
-            return InitializeResult(capabilities = com.monkopedia.lsp.ServerCapabilities())
+            return InitializeResult(capabilities = ServerCapabilities())
         }
-        return handshakeEngine(server, params)
+        val fresh = EngineConnection(server)
+        connection = fresh
+        return handshakeEngine(fresh, params)
     }
 
     /**
-     * Drive a freshly-[connect][KotlinLspProcess.connect]ed [server] through the engine
-     * handshake and (re)build the pull publisher, returning its [InitializeResult]. Shared by
+     * Drive a freshly-[connect][KotlinLspProcess.connect]ed [connection] through the engine
+     * handshake and build its pull publisher, returning the engine's [InitializeResult]. Shared by
      * the first [initialize] and by [reconnect] after a crash, so both replay the IDENTICAL init.
      */
     private suspend fun handshakeEngine(
-        server: KsrpcLanguageServer,
+        connection: EngineConnection,
         params: InitializeParams
     ): InitializeResult {
         // Drive the subprocess through the same handshake, but rooted at the synthesized
@@ -300,7 +316,7 @@ open class BridgeLanguageServer(
             "initialize",
             InitializeResult(capabilities = ServerCapabilities())
         ) {
-            server.initialize(
+            connection.server.initialize(
                 params.copy(
                     rootUri = lspWorkspace.rootUri,
                     workspaceFolders = null,
@@ -312,27 +328,28 @@ open class BridgeLanguageServer(
         // engine's capabilities is the only signal (there is no push capability flag). Only
         // then do we stand up the event-driven pull→push publisher; otherwise no pull
         // machinery runs at all.
-        diagnostics = PullDiagnosticsPublisher.pullProviderOf(result.capabilities)
-            ?.let { provider -> createPublisher(server, provider) }
+        connection.diagnostics = PullDiagnosticsPublisher.pullProviderOf(result.capabilities)
+            ?.let { provider -> createPublisher(connection, provider) }
         return result
     }
 
     /**
-     * Build the [PullDiagnosticsPublisher] wired to THIS bridge's subprocess [server] and
-     * frontend client. The publisher owns the pull/refresh/previousResultId/debounce/backoff
-     * logic; the bridge supplies only the three seams:
+     * Build the [PullDiagnosticsPublisher] wired to THIS [connection]'s engine stub and the
+     * frontend client. The publisher owns the pull/refresh/previousResultId/debounce/retry logic
+     * and runs it all in [EngineConnection.scope], so it stops the moment that connection is
+     * replaced or torn down (#80). The bridge supplies only the three seams:
      *  - the PULL (subprocess `textDocument/diagnostic`, threading `previousResultId`),
      *  - the PUBLISH (translate ranges to csgs space + rewrite the URI, then push up), and
      *  - the readiness gate (the editor's `initialized` handshake).
      */
     private fun createPublisher(
-        server: KsrpcLanguageServer,
+        connection: EngineConnection,
         provider: com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider
     ): PullDiagnosticsPublisher = PullDiagnosticsPublisher(
-        scope = scope,
+        scope = connection.scope,
         diagnosticProvider = provider,
         pull = { _, previousResultId ->
-            server.textDocumentDiagnostic(
+            connection.server.textDocumentDiagnostic(
                 DocumentDiagnosticParams(
                     textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri),
                     previousResultId = previousResultId
@@ -355,13 +372,13 @@ open class BridgeLanguageServer(
     override suspend fun initialized(params: InitializedParams) {
         // Remember the editor sent `initialized` so [reconnect] replays it to the fresh engine.
         initializedParams = params
-        delegate?.let { runCatching { it.initialized(params) } }
+        connection?.let { runCatching { it.server.initialized(params) } }
         // Now the editor has initialized; release the forwarder so it can push.
         lifecycle.advanceTo(LifecycleState.Phase.INITIALIZED)
     }
 
     override suspend fun textDocumentDidOpen(params: DidOpenTextDocumentParams) {
-        if (delegate == null) return
+        if (connection == null) return
         // Remember the editor's URI so subprocess diagnostics get routed back to it.
         frontendUri = params.textDocument.uri
         // Retain the live open doc so a post-crash [reconnect] can replay this didOpen (#54).
@@ -386,13 +403,13 @@ open class BridgeLanguageServer(
                 )
             )
         }
-        // Event-driven (#43): pull now (with cold-index backoff for this first pull only),
+        // Event-driven (#43): pull now (with the cold-index retry for this first pull only),
         // then rely on didChange/refresh. Routes by the frontend's csgs URI.
-        diagnostics?.onOpen(params.textDocument.uri)
+        connection?.diagnostics?.onOpen(params.textDocument.uri)
     }
 
     override suspend fun textDocumentDidChange(params: DidChangeTextDocumentParams) {
-        if (delegate == null) return
+        if (connection == null) return
         // Full-document sync (v1): the editor sends the whole edited csgs as the change
         // text (kodemirror full-sync; these files are tiny). Take the last change's text
         // as the live document, re-wrap it into the .kt form so the engine analyzes the
@@ -421,11 +438,11 @@ open class BridgeLanguageServer(
             )
         }
         // Event-driven (#43): debounced re-pull for the new content (coalesces edit bursts).
-        diagnostics?.onChange(params.textDocument.uri)
+        connection?.diagnostics?.onChange(params.textDocument.uri)
     }
 
     override suspend fun textDocumentDidClose(params: DidCloseTextDocumentParams) {
-        val server = delegate ?: return
+        val current = connection ?: return
         // The doc is closing: nothing to replay on a future reconnect. (A dead engine on close
         // needs no self-heal — the session is ending — so this path stays a plain guarded call.)
         openDocument = null
@@ -434,9 +451,9 @@ open class BridgeLanguageServer(
         // to leave openDocs/resultIds (uri-space key consistency — a mismatched key would leak
         // the doc and keep re-pulling it on every refresh after close). The publisher's own
         // publish seam translates to the wrapped uri at the boundary.
-        diagnostics?.onClose(params.textDocument.uri)
+        current.diagnostics?.onClose(params.textDocument.uri)
         runCatching {
-            server.textDocumentDidClose(
+            current.server.textDocumentDidClose(
                 DidCloseTextDocumentParams(
                     textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri)
                 )
@@ -445,7 +462,7 @@ open class BridgeLanguageServer(
     }
 
     /**
-     * Run a subprocess-facing ([delegate]) call, degrading to [fallback] if it fails.
+     * Run a subprocess-facing ([connection]) call, degrading to [fallback] if it fails.
      *
      * Failure isolation (observed live 2026-06-10): the kotlin-lsp subprocess can crash
      * mid-session. A throwing delegate call must NOT propagate an exception out of an LSP
@@ -474,7 +491,7 @@ open class BridgeLanguageServer(
         }
 
     /**
-     * Run a subprocess-facing call against the CURRENT [delegate], and — if the engine has
+     * Run a subprocess-facing call against the CURRENT [connection], and — if the engine has
      * crashed — transparently self-heal (#54): on failure, attempt a single-flight [reconnect]
      * against the respawned subprocess, then retry [block] ONCE against the fresh delegate. If the
      * engine is still dead after the reconnect attempt, degrade to [fallback] (never throwing —
@@ -484,70 +501,78 @@ open class BridgeLanguageServer(
      * one a captured reference would hold. At most one reconnect + one retry per failing call: no
      * backoff/retry-limit machinery — recovery is paced by request traffic (a subsequent request
      * that still fails simply tries again).
+     *
+     * Only ever called from an editor-facing method, i.e. NEVER from inside an
+     * [EngineConnection.scope] — [reconnect] cancels that scope, and a caller running in it would
+     * be cancelling itself mid-reconnect.
      */
     private suspend fun <T> withLiveDelegate(
         label: String,
         fallback: T,
         block: suspend (KsrpcLanguageServer) -> T
     ): T {
-        val server = delegate ?: return fallback
+        val dead = connection ?: return fallback
         return try {
-            block(server)
+            block(dead.server)
         } catch (t: Throwable) {
             // Cooperative cancellation of THIS coroutine must propagate; a foreign cancellation
             // (the dead engine leg) must not — see [guardEngine] for the full rationale.
             coroutineContext.ensureActive()
             hauler.error("kotlin-lsp '$label' failed; attempting reconnect", t)
             // Single-flight re-establish against the (respawned) subprocess. If it yields a fresh,
-            // live delegate, retry the call once against it; otherwise stay inert for this call.
-            val fresh = reconnect(deadServer = server)
-            if (fresh == null || fresh === server) {
+            // live connection, retry the call once against it; otherwise stay inert for this call.
+            val fresh = reconnect(dead)
+            if (fresh == null || fresh === dead) {
                 fallback
             } else {
-                guardEngine("$label (post-reconnect retry)", fallback) { block(fresh) }
+                guardEngine("$label (post-reconnect retry)", fallback) { block(fresh.server) }
             }
         }
     }
 
     /**
-     * Self-heal the delegate after an engine crash (#54): re-[connect][KotlinLspProcess.connect] a
-     * fresh subprocess-facing stub (the process manager respawns a dead subprocess on connect),
-     * replay the [initialize]/`initialized` handshake, and re-`didOpen` the current document so the
-     * respawned engine resumes analyzing what the user has open. Returns the fresh [delegate], or
-     * the current one unchanged if another concurrent call already reconnected, or `null` if the
-     * engine is still unavailable.
+     * Self-heal after an engine crash (#54): cancel the [dead] connection's scope,
+     * re-[connect][KotlinLspProcess.connect] a fresh subprocess-facing stub (the process manager
+     * respawns a dead subprocess on connect), replay the [initialize]/`initialized` handshake, and
+     * re-`didOpen` the current document so the respawned engine resumes analyzing what the user has
+     * open. Returns the fresh [connection], or the current one unchanged if another concurrent call
+     * already reconnected, or `null` if the engine is still unavailable.
      *
-     * Single-flight: guarded by [reconnectLock] and keyed on [deadServer] — the caller that
-     * observed a failure passes the delegate it was using; if [delegate] no longer === that stub,
-     * another coroutine already reconnected (or [teardown] nulled it) so we do NOT reconnect again.
-     * This both dedupes the N-concurrent-failures storm and prevents resurrecting the delegate
-     * after teardown (post-teardown [delegate] is null, so it can never === a non-null deadServer).
+     * Single-flight: guarded by [reconnectLock] and keyed on [dead] — the caller that observed a
+     * failure passes the connection it was using; if [connection] is no longer that one, another
+     * coroutine already reconnected (or [teardown] nulled it) so we do NOT reconnect again. This
+     * both dedupes the N-concurrent-failures storm and prevents resurrecting the connection after
+     * teardown (post-teardown [connection] is null, so it can never === a non-null [dead]).
      *
      * Failure-isolated: any error here is swallowed to `null` (bridge stays inert), never thrown —
      * preserving the [guardEngine] no-cascade contract.
      */
-    private suspend fun reconnect(deadServer: KsrpcLanguageServer): KsrpcLanguageServer? =
+    private suspend fun reconnect(dead: EngineConnection): EngineConnection? =
         reconnectLock.withLock {
-            // Torn down (scope cancelled): never resurrect the delegate.
+            // Torn down (connection cancelled): never resurrect it.
             if (torndown) return@withLock null
             // Another concurrent failure already reconnected, or teardown ran: nothing to do.
-            if (delegate !== deadServer) return@withLock delegate
+            if (connection !== dead) return@withLock connection
             val params = initializeParams ?: return@withLock null
+            // The engine behind this connection is gone, so everything scoped to it is pointless
+            // (#80): cancel it here — before the respawn — so a publisher mid-pull cannot keep
+            // polling the corpse alongside the fresh connection's own. Not joined: we must not
+            // block the reconnect (holding [reconnectLock]) on work stuck against a dead engine.
+            dead.scope.cancel()
             try {
                 // connectEngine respawns the subprocess if it died, and returns a fresh stub wired
                 // to a new Forwarder for THIS bridge's session.
-                val fresh = connectEngine()
+                val server = connectEngine()
                     ?: return@withLock null.also {
                         hauler.error("kotlin-lsp reconnect failed to respawn; bridge stays inert")
                     }
-                delegate = fresh
+                val fresh = EngineConnection(server)
+                connection = fresh
                 hauler.info("kotlin-lsp reconnected; replaying handshake + didOpen")
-                // Replay the engine handshake (this also rebuilds the pull publisher against the
-                // fresh stub) and, if the editor had already initialized, its `initialized`.
+                // Replay the engine handshake (this also builds the pull publisher against the
+                // fresh connection) and, if the editor had already initialized, its `initialized`.
                 handshakeEngine(fresh, params)
-                if (initializedParams != null) {
-                    runCatching { fresh.initialized(initializedParams!!) }
-                }
+                initializedParams?.let { runCatching { server.initialized(it) } }
                 // Re-open the current document so the engine re-analyzes what the user has open.
                 replayDidOpen(fresh)
                 fresh
@@ -560,15 +585,16 @@ open class BridgeLanguageServer(
         }
 
     /**
-     * Replay a `didOpen` for the current [openDocument] against a freshly-reconnected [server], and
-     * re-trigger the diagnostics pull. No-op if no document is open. Mirrors [textDocumentDidOpen]'s
-     * wrap-then-open, using the retained live content (kept current by didOpen/didChange).
+     * Replay a `didOpen` for the current [openDocument] against a freshly-reconnected [connection],
+     * and re-trigger the diagnostics pull. No-op if no document is open. Mirrors
+     * [textDocumentDidOpen]'s wrap-then-open, using the retained live content (kept current by
+     * didOpen/didChange).
      */
-    private suspend fun replayDidOpen(server: KsrpcLanguageServer) {
+    private suspend fun replayDidOpen(connection: EngineConnection) {
         val doc = openDocument ?: return
         lspWorkspace.synthesize(content = doc.csgsText)
         guardEngine("reconnect didOpen", Unit) {
-            server.textDocumentDidOpen(
+            connection.server.textDocumentDidOpen(
                 DidOpenTextDocumentParams(
                     textDocument = TextDocumentItem(
                         uri = lspWorkspace.documentUri,
@@ -579,7 +605,7 @@ open class BridgeLanguageServer(
                 )
             )
         }
-        diagnostics?.onOpen(doc.uri)
+        connection.diagnostics?.onOpen(doc.uri)
     }
 
     /**
@@ -593,7 +619,7 @@ open class BridgeLanguageServer(
     override suspend fun textDocumentCompletion(
         params: CompletionParams
     ): TextDocumentCompletionResult? {
-        if (delegate == null) return null
+        if (connection == null) return null
         // lsp-types 1.2.0 types this spec-nullable result honestly: a server returning `null`
         // (no completions / index not ready) decodes to `null`. A crashed engine, though, would
         // THROW — and an exception escaping here rides up the shared frontend connection and
@@ -616,7 +642,7 @@ open class BridgeLanguageServer(
      * back to csgs space too.
      */
     override suspend fun completionItemResolve(params: CompletionItem): CompletionItem {
-        if (delegate == null) return params
+        if (connection == null) return params
         return withLiveDelegate("completionItemResolve", params) { server ->
             translateCompletionItem(server.completionItemResolve(params))
         }
@@ -629,7 +655,7 @@ open class BridgeLanguageServer(
      * through untouched.
      */
     override suspend fun textDocumentHover(params: HoverParams): Hover? {
-        if (delegate == null) return null
+        if (connection == null) return null
         // Hover is `Hover | null` per spec: kotlin-lsp returns null for hover-over-nothing, which
         // the editor fires on every cursor move. lsp-types 1.2.0 types it nullable, so null now
         // decodes to null (no exception, no scope cancellation). Return null → editor shows no
@@ -666,7 +692,7 @@ open class BridgeLanguageServer(
      * document positions, so it passes through unchanged.
      */
     override suspend fun textDocumentSignatureHelp(params: SignatureHelpParams): SignatureHelp? {
-        if (delegate == null) return null
+        if (connection == null) return null
         // `SignatureHelp | null` per spec (null when the cursor isn't in a call). lsp-types 1.2.0
         // types it nullable, so null propagates cleanly instead of throwing; a crashed engine is
         // guarded to inert so it can't take the shared connection down.
@@ -708,8 +734,8 @@ open class BridgeLanguageServer(
      * `lsp()` sub-service AND the reverse [frontendClient] channel would stay registered
      * until the whole socket closes — leaking two sub-channels per open→close cycle.
      *
-     * So on close we [teardown] (cancel the bridge scope, stop the publisher, exit+close the
-     * subprocess-facing stub) AND additionally [close][KsrpcLanguageClient.close] the
+     * So on close we [teardown] (didClose the document, cancel the engine connection's scope and
+     * with it the publisher) AND additionally [close][KsrpcLanguageClient.close] the
      * stashed [frontendClient], which drops our reference to its reverse channel and lets
      * ksrpc reclaim it. Idempotent and ordered after [teardown] so the publisher (which
      * pushes to [frontendClient]) is already stopped before we release it.
@@ -724,37 +750,38 @@ open class BridgeLanguageServer(
     }
 
     /**
-     * Per-konstruction cleanup. Drops the publisher, sends a best-effort `didClose` so the
-     * SHARED engine forgets this konstruction's document, then cancels the bridge scope and
-     * waits for it to fully stop. Deliberately does NOT `shutdown`/`exit`/`close` the
-     * subprocess-facing [delegate] stub, because that stub rides the shared keep-warm
-     * connection — closing it would kill the engine for other open konstructions and break
-     * the next reopen. Idempotent: a second pass is a no-op once [delegate] is nulled.
+     * Per-konstruction cleanup. Sends a best-effort `didClose` so the SHARED engine forgets this
+     * konstruction's document, then cancels the connection's scope (stopping the publisher and
+     * anything else scoped to it) and waits for it to fully stop. Deliberately does NOT
+     * `shutdown`/`exit`/`close` the subprocess-facing stub, because it rides the shared keep-warm
+     * connection — closing it would kill the engine for other open konstructions and break the next
+     * reopen. Idempotent: a second pass is a no-op once [connection] is nulled.
      */
     private suspend fun teardown() {
         // Take [reconnectLock] and set [torndown] so an in-flight self-heal (#54) can't resurrect
-        // the delegate after we null it; then release the delegate under the lock. A reconnect
-        // queued behind us will see [torndown] and bail.
-        reconnectLock.withLock {
+        // the connection after we null it; then release it under the lock. A reconnect queued
+        // behind us will see [torndown] and bail.
+        val dead = reconnectLock.withLock {
             torndown = true
-            diagnostics = null
             openDocument = null
-            delegate?.let { server ->
+            val current = connection
+            connection = null
+            current?.let {
                 // Tell the shared engine to forget our document (no-op if didClose already ran).
                 runCatching {
-                    server.textDocumentDidClose(
+                    it.server.textDocumentDidClose(
                         DidCloseTextDocumentParams(
                             textDocument = TextDocumentIdentifier(uri = lspWorkspace.documentUri)
                         )
                     )
                 }
             }
-            delegate = null
+            current
         }
-        // cancelAndJoin: wait for all scope children (hauler writers, etc.) to actually finish
-        // before returning, so callers that free resources (e.g. the temp dir in tests) do not
-        // race with in-flight IO coroutines.
-        scope.coroutineContext[Job]?.cancelAndJoin()
+        // cancelAndJoin: unlike [reconnect]'s fire-and-forget cancel, teardown waits for the
+        // connection's children to actually finish, so callers that free resources (e.g. the temp
+        // dir in tests) do not race with in-flight IO coroutines.
+        dead?.scope?.coroutineContext?.job?.cancelAndJoin()
     }
 
     /**

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisher.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisher.kt
@@ -27,12 +27,14 @@ import com.monkopedia.lsp.RelatedUnchangedDocumentDiagnosticReport
 import com.monkopedia.lsp.ServerCapabilities
 import com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -62,7 +64,8 @@ import kotlinx.coroutines.sync.withLock
  * (extraction-time affordances captured on #40: optional `identifier` keying resultId by
  * (uri, identifier?); `version` through the publish seam; `awaitReady` as a generic
  * `suspend () -> Unit`; the teardown contract — the publisher relies on its injected [scope]
- * being cancelled, which `BridgeLanguageServer.close()` does).
+ * being cancelled, which the bridge does whenever the engine connection it belongs to dies, is
+ * replaced or is torn down (#80), and which is the ONLY thing that bounds its pulls).
  *  - [pull]: how to PULL a [DocumentDiagnosticReport] for a doc (the subprocess stub's
  *    `textDocumentDiagnostic`, with `previousResultId`),
  *  - [publish]: how to PUSH a doc's diagnostics up to the target client (the bridge wires
@@ -70,7 +73,7 @@ import kotlinx.coroutines.sync.withLock
  *    `textDocumentPublishDiagnostics`),
  *  - [awaitReady]: a gate suspended on until the target client is ready to receive (the
  *    `initialized` handshake), and
- *  - timing knobs ([debounce], cold-index [backoff]).
+ *  - timing knobs ([debounce], [coldIndexRetry]).
  *
  * It tracks per-doc [previousResultId][DocumentDiagnosticParams.previousResultId] (see
  * [resultIds]); on each pull it threads the last id, and when the server answers an
@@ -79,9 +82,9 @@ import kotlinx.coroutines.sync.withLock
  * `kind == "full"`) emits a `publishDiagnostics`. This kills redundant upward pushes.
  *
  * Triggers:
- *  - [onOpen] — pull immediately (the doc just opened); bounded cold-index backoff applies
- *    to this FIRST pull only, since the index may not be warm yet (a pull can transiently
- *    fail or come back empty before analysis settles).
+ *  - [onOpen] — pull immediately (the doc just opened); the [coldIndexRetry] applies to this
+ *    FIRST pull only, since the index may not be warm yet (a pull can transiently fail or
+ *    come back empty before analysis settles).
  *  - [onChange] — debounced pull for that doc (coalesces a burst of edits/saves).
  *  - [onRefresh] — re-pull **all** open docs; this is the engine's
  *    `workspace/diagnostic/refresh` (the cold-index-warmed case), and is the steady-state
@@ -109,7 +112,8 @@ internal class PullDiagnosticsPublisher(
     /** Suspends until the target client has signalled it is ready (the `initialized` gate). */
     private val awaitReady: suspend () -> Unit,
     private val debounce: Duration = DEFAULT_DEBOUNCE,
-    private val backoff: ColdIndexBackoff = ColdIndexBackoff(),
+    /** How long to wait between re-tries of the FIRST pull, while the index is still cold. */
+    private val coldIndexRetry: Duration = DEFAULT_COLD_INDEX_RETRY,
     /**
      * Whether [onClose] emits a clearing `publish(uri, emptyList())` so the editor drops the
      * last squiggles when a doc closes (kodemirror does not always clear on its own didClose).
@@ -149,16 +153,16 @@ internal class PullDiagnosticsPublisher(
     private fun lockFor(uri: String): Mutex = pullLocks.getOrPut(uri) { Mutex() }
 
     /**
-     * Register `uri` as open and pull its diagnostics now, with bounded cold-index backoff
-     * (this first pull may race the index warming). Replaces the Phase 2 unconditional
-     * retry loop: once the engine sends a refresh we're event-driven, so backoff applies
+     * Register `uri` as open and pull its diagnostics now, retrying while the index is still
+     * cold (this first pull may race the index warming). Replaces the Phase 2 unconditional
+     * retry loop: once the engine sends a refresh we're event-driven, so the retry applies
      * ONLY to this initial pull.
      */
     fun onOpen(uri: String) {
         openDocs.add(uri)
         scope.launch {
             awaitReady()
-            pullWithColdIndexBackoff(uri)
+            pullUntilPublished(uri)
         }
     }
 
@@ -226,9 +230,17 @@ internal class PullDiagnosticsPublisher(
      */
     private suspend fun pullOnce(uri: String): PullOutcome = lockFor(uri).withLock {
         val previousResultId = resultIds[uri]
-        val report = runCatching { pull(uri, previousResultId) }
-            .onFailure { hauler.error("pull diagnostics failed for $uri", it) }
-            .getOrElse { return@withLock PullOutcome.FAILED }
+        val report = try {
+            pull(uri, previousResultId)
+        } catch (t: Throwable) {
+            // Our own cancellation must propagate, not be logged as an engine error and retried:
+            // it is how [pullUntilPublished] stops when the engine connection is cancelled (#80).
+            // A FOREIGN CancellationException (the dead engine leg) is an engine failure like any
+            // other, which is why this is ensureActive() and not `catch (e: CancellationException)`.
+            coroutineContext.ensureActive()
+            hauler.error("pull diagnostics failed for $uri", t)
+            return@withLock PullOutcome.FAILED
+        }
         when (report) {
             is RelatedFullDocumentDiagnosticReport -> {
                 report.resultId?.let { resultIds[uri] = it }
@@ -250,40 +262,25 @@ internal class PullDiagnosticsPublisher(
     }
 
     /**
-     * The first pull after [onOpen]: retry with bounded backoff until we either publish or
-     * exhaust attempts. The cold index can take ~120s to settle, so a pull may transiently
-     * fail or come back empty before analysis lands; once it publishes (or the doc closes)
-     * we stop and rely on event-driven [onRefresh]/[onChange].
+     * The first pull after [onOpen]: retry every [coldIndexRetry] until it publishes. The cold
+     * index can take ~120s to settle, so a pull may transiently fail or come back empty before
+     * analysis lands; once it publishes (or the doc closes) we stop and rely on event-driven
+     * [onRefresh]/[onChange]. It needs no attempt limit of its own: the loop is bounded by the
+     * [scope] it runs in, which the caller cancels when the engine connection dies or is replaced
+     * (#80) — so it can never outlive the engine it is polling.
      */
-    private suspend fun pullWithColdIndexBackoff(uri: String) {
-        var attempt = 0
-        while (attempt < backoff.maxAttempts && uri in openDocs) {
-            val outcome = pullOnce(uri)
-            if (outcome == PullOutcome.PUBLISHED) return
-            attempt++
-            delay(backoff.interval)
+    private suspend fun pullUntilPublished(uri: String) {
+        while (uri in openDocs) {
+            if (pullOnce(uri) == PullOutcome.PUBLISHED) return
+            delay(coldIndexRetry)
         }
     }
 
     private enum class PullOutcome { PUBLISHED, UNCHANGED, FAILED, SKIPPED_CLOSED }
 
-    /**
-     * Bounded backoff for the FIRST pull only (before the index warms). Not a steady-state
-     * poll: after the first publish we go event-driven (refresh/change). Defaults are
-     * generous enough to cover a cold index (~120s) without an unbounded loop.
-     */
-    data class ColdIndexBackoff(
-        val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
-        val interval: Duration = DEFAULT_INTERVAL
-    ) {
-        private companion object {
-            private const val DEFAULT_MAX_ATTEMPTS = 40
-            private val DEFAULT_INTERVAL = 4.seconds
-        }
-    }
-
     companion object {
         private val DEFAULT_DEBOUNCE = 300.milliseconds
+        private val DEFAULT_COLD_INDEX_RETRY = 4.seconds
 
         /**
          * The authoritative pull-mode signal: the initialize result's

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServerReconnectTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServerReconnectTest.kt
@@ -24,13 +24,18 @@ import com.monkopedia.lsp.CompletionItem
 import com.monkopedia.lsp.CompletionParams
 import com.monkopedia.lsp.DefaultLanguageClient
 import com.monkopedia.lsp.DefaultLanguageServer
+import com.monkopedia.lsp.DiagnosticOptions
 import com.monkopedia.lsp.DidOpenTextDocumentParams
+import com.monkopedia.lsp.DocumentDiagnosticParams
+import com.monkopedia.lsp.DocumentDiagnosticReport
 import com.monkopedia.lsp.InitializeParams
 import com.monkopedia.lsp.InitializeResult
 import com.monkopedia.lsp.InitializedParams
 import com.monkopedia.lsp.KsrpcLanguageServer
 import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
 import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider
 import com.monkopedia.lsp.TextDocumentCompletionResult
 import com.monkopedia.lsp.TextDocumentIdentifier
 import com.monkopedia.lsp.TextDocumentItem
@@ -42,7 +47,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 
 /**
  * Self-heal-after-crash guard for [BridgeLanguageServer] (#54), exercised WITHOUT a real
@@ -56,8 +65,10 @@ import kotlinx.coroutines.runBlocking
  *    retries once (LSP resumes without a file reopen),
  *  - the reconnect replays the engine handshake (`initialize` + `initialized`) and re-`didOpen`s the
  *    CURRENT document,
- *  - concurrent failing calls single-flight the reconnect (one respawn, not N), and
- *  - after teardown the bridge never resurrects the delegate.
+ *  - concurrent failing calls single-flight the reconnect (one respawn, not N),
+ *  - after teardown the bridge never resurrects the delegate, and
+ *  - the replaced connection's scope is cancelled, so work launched against the dead engine (the
+ *    diagnostics pull) stops there and then rather than running on (#80).
  */
 class BridgeLanguageServerReconnectTest {
 
@@ -83,12 +94,25 @@ class BridgeLanguageServerReconnectTest {
     }
 
     /** A fake engine stub. Forward calls throw while [crashed]; otherwise they record + respond. */
-    private class FakeEngine(val id: Int, val crashed: AtomicBoolean = AtomicBoolean(false)) :
-        DefaultLanguageServer() {
+    private class FakeEngine(
+        val id: Int,
+        val crashed: AtomicBoolean = AtomicBoolean(false),
+        /** Non-null ⇒ the fake advertises pull mode, so the bridge stands up a publisher. */
+        private val diagnosticProvider: ServerCapabilitiesDiagnosticProvider? = null
+    ) : DefaultLanguageServer() {
         val initializes = CopyOnWriteArrayList<InitializeParams>()
         val initializedCalls = CopyOnWriteArrayList<InitializedParams>()
         val didOpens = CopyOnWriteArrayList<DidOpenTextDocumentParams>()
         val completions = CopyOnWriteArrayList<CompletionParams>()
+
+        /** Completes once a diagnostics pull has reached this engine and parked on the gate. */
+        val pullStarted = CompletableDeferred<Unit>()
+
+        /** Completes if a parked pull is CANCELLED — i.e. the work scoped to it was stopped. */
+        val pullCancelled = CompletableDeferred<Unit>()
+
+        /** Never completed: a pull parks here so the test can observe what happens to it. */
+        private val pullGate = CompletableDeferred<Unit>()
 
         private fun crashIfDead() {
             if (crashed.get()) error("fake kotlin-lsp #$id crashed")
@@ -97,8 +121,27 @@ class BridgeLanguageServerReconnectTest {
         override suspend fun initialize(params: InitializeParams): InitializeResult {
             crashIfDead()
             initializes.add(params)
-            // No diagnosticProvider ⇒ no pull publisher; the test focuses on delegate self-heal.
-            return InitializeResult(capabilities = ServerCapabilities())
+            return InitializeResult(
+                capabilities = ServerCapabilities(diagnosticProvider = diagnosticProvider)
+            )
+        }
+
+        /**
+         * A pull that never answers: it records that it started and then parks, so the test can
+         * assert whether the coroutine driving it is still alive after a reconnect.
+         */
+        override suspend fun textDocumentDiagnostic(
+            params: DocumentDiagnosticParams
+        ): DocumentDiagnosticReport {
+            crashIfDead()
+            pullStarted.complete(Unit)
+            try {
+                pullGate.await()
+            } catch (e: CancellationException) {
+                pullCancelled.complete(Unit)
+                throw e
+            }
+            return RelatedFullDocumentDiagnosticReport(kind = "full", items = emptyList())
         }
 
         override suspend fun initialized(params: InitializedParams) {
@@ -267,6 +310,38 @@ class BridgeLanguageServerReconnectTest {
             bridge.handedOut.size,
             "teardown must prevent any reconnect (no second engine handed out)"
         )
+    }
+
+    @Test
+    fun `reconnect cancels the work scoped to the dead connection`() = runBlocking {
+        seedContent("val a = 1\n")
+        val pullMode =
+            DiagnosticOptions(interFileDependencies = false, workspaceDiagnostics = false)
+        val first = FakeEngine(id = 1, diagnosticProvider = pullMode)
+        val second = FakeEngine(id = 2, diagnosticProvider = pullMode)
+        val queue = ArrayDeque(listOf(first, second))
+        val bridge = FakeEngineBridge(env.config, workspaceId, konstructionId) {
+            queue.removeFirstOrNull()
+        }
+        bridge.initialize(
+            InitializeParams(capabilities = ClientCapabilities(), rootUri = "file:///$workspaceId")
+        )
+        bridge.initialized(InitializedParams())
+        bridge.textDocumentDidOpen(openParams("val a = 1\n"))
+        // The first connection's publisher is now mid-pull against the first engine.
+        withTimeout(10.seconds) { first.pullStarted.await() }
+
+        // The engine crashes and the next request self-heals onto the second engine.
+        first.crashed.set(true)
+        bridge.textDocumentCompletion(completionAt())
+
+        // The dead connection's scope goes with it, so its in-flight pull is cancelled instead of
+        // polling on against the corpse until some private countdown expires (#80)...
+        withTimeout(10.seconds) { first.pullCancelled.await() }
+        // ...and the pulling has moved to the fresh connection.
+        withTimeout(10.seconds) { second.pullStarted.await() }
+
+        bridge.close()
     }
 
     @Test

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisherTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisherTest.kt
@@ -24,12 +24,18 @@ import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
 import com.monkopedia.lsp.RelatedUnchangedDocumentDiagnosticReport
 import com.monkopedia.lsp.ServerCapabilities
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -42,6 +48,9 @@ import kotlinx.coroutines.test.runTest
  *  - **`unchanged`-report skip** — an unchanged report must NOT republish.
  *  - **`previousResultId` threading** — the last `resultId` is fed to the next pull.
  *  - **refresh → re-pull** — `onRefresh` re-pulls every open doc.
+ *
+ * Plus the teardown contract the publisher now relies on (#80): the cold-index retry has no
+ * attempt countdown of its own, so cancelling the injected scope must stop it.
  */
 class PullDiagnosticsPublisherTest {
 
@@ -61,8 +70,6 @@ class PullDiagnosticsPublisherTest {
         range = Range(start = Position(0u, 0u), end = Position(0u, 0u)),
         message = message
     )
-
-    private val noBackoff = PullDiagnosticsPublisher.ColdIndexBackoff(maxAttempts = 1)
 
     /** A pull/publish recorder driving the publisher with scripted reports. */
     private class Recorder {
@@ -323,7 +330,37 @@ class PullDiagnosticsPublisherTest {
         )
     }
 
-    private fun kotlinx.coroutines.CoroutineScope.newPublisher(
+    // --- cancellation is what bounds the cold-index retry (#80) -----------------------
+
+    @Test
+    fun `the cold-index retry runs until its scope is cancelled`() = runTest {
+        val rec = Recorder()
+        rec.reports = { error("engine is down") }
+        // The publisher is launched in the ENGINE CONNECTION's scope (#80), which the bridge
+        // cancels when that connection dies or is replaced.
+        val connectionScope = CoroutineScope(coroutineContext + Job())
+        val publisher = connectionScope.newPublisher(rec)
+
+        publisher.onOpen(uri)
+        testScheduler.advanceTimeBy(30.seconds)
+        val whileConnected = rec.pullCalls.size
+        assertTrue(
+            whileConnected > 1,
+            "a failing first pull must keep retrying while the connection lives; got $whileConnected"
+        )
+
+        // Cancelling the connection's scope is the ONLY thing that bounds the retry — there is no
+        // attempt countdown any more.
+        connectionScope.cancel()
+        testScheduler.advanceTimeBy(5.minutes)
+        assertEquals(
+            whileConnected,
+            rec.pullCalls.size,
+            "a cancelled scope must stop the retry dead, not keep polling a dead engine"
+        )
+    }
+
+    private fun CoroutineScope.newPublisher(
         rec: Recorder,
         provider: com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider = DiagnosticOptions(
             interFileDependencies = false,
@@ -341,7 +378,6 @@ class PullDiagnosticsPublisherTest {
             rec.publishUris.add(uri)
             rec.publishes.add(diagnostics)
         },
-        awaitReady = { },
-        backoff = noBackoff
+        awaitReady = { }
     )
 }


### PR DESCRIPTION
Fixes #80.

## The problem

PR #76 gave the bridge self-heal reconnect, but the *work* attached to a connection was owned by the bridge, not the connection. When the engine died and `reconnect()` swapped in a fresh delegate, the previous `PullDiagnosticsPublisher` kept polling the corpse until its own 40-attempt countdown ran out (~160s of failing pulls and error logs). Bounded, but only because that one consumer carried a countdown — anything else scoped to the engine would have needed its own.

## The change

`EngineConnection` (a private holder in `BridgeLanguageServer`) owns the subprocess stub, a `CoroutineScope` that every piece of work launched on that engine's behalf runs in, and the pull publisher fed by it. `reconnect()` and `teardown()` cancel that scope, so structured concurrency stops everything attached to a dead connection in one move.

Net effect on the bridge's state: `delegate` + `diagnostics` collapse into one `connection` field, and the bridge-wide `scope` (whose only child was ever the publisher) is deleted.

**Deleted mechanism.** With cancellation doing the bounding, the publisher's retry countdown is redundant: the `ColdIndexBackoff(maxAttempts = 40, interval = 4s)` data class collapses to a single `coldIndexRetry: Duration` constructor knob, and `pullWithColdIndexBackoff` becomes `pullUntilPublished` — it runs until it publishes, the doc closes, or its scope is cancelled. This is the tradeoff-3 item left open in #76's review: a cancelled connection can't keep respawning work.

## Cancellation correctness

- `reconnect` cancels the dead scope **without joining it** — it must not block (while holding `reconnectLock`) on work stuck against a dead engine. `teardown` still `cancelAndJoin`s, because its callers free resources right after (the temp dir in tests).
- **Cancelling the old scope can't kill the reconnect that replaces it**: `withLiveDelegate` is the only path into `reconnect`, and it is only ever called from editor-facing LSP methods — never from inside a connection scope. That invariant is now stated in its KDoc.
- `pullOnce` no longer swallows its own `CancellationException` inside `runCatching` (which would have logged our cancellation as an engine error). It uses the same `coroutineContext.ensureActive()` idiom as `guardEngine`, so *our* cancellation propagates while a *foreign* one (the dead engine leg surfacing through a call) is still treated as an engine failure, not a cascade.
- `teardown`'s `torndown` flag still wins: a reconnect queued behind teardown bails, and post-teardown `connection` is null so it can never `===` a non-null dead connection.
- Nothing here closes the subprocess-facing stub — it rides `KotlinLspProcess`'s shared keep-warm connection, same as before — so a cancelled scope can't leave a half-closed engine.

## Tests

- `BridgeLanguageServerReconnectTest.reconnect cancels the work scoped to the dead connection` — the fake engine now advertises pull mode and parks its `textDocument/diagnostic` on a gate that never completes, recording if that pull is cancelled. The test waits for the pull to park, crashes the engine, drives a completion (which self-heals), then asserts the parked pull was cancelled and that pulling moved to the fresh connection. **Verified to fail against the pre-change bridge** (stash the production file → `TimeoutCancellationException`, other 4 reconnect tests still green).
- `PullDiagnosticsPublisherTest.the cold-index retry runs until its scope is cancelled` — pins the contract that replaced the countdown: a permanently-failing first pull keeps retrying while the connection lives, and stops dead when the injected scope is cancelled.

## Verification

```
JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :backend:jvmTest :protocol:jvmTest  → BUILD SUCCESSFUL (137 tests, 0 failures, 15 skipped/gated)
JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew spotlessCheck                       → BUILD SUCCESSFUL
```

The real-engine integration test (`-Dintegration=true` + `KONSTRUCTOR_KOTLIN_LSP`) was **not** run: no engine binary is present on this box (`/home/jmonk/kotlin-lsp` does not exist).

## Known tradeoff

The cold-index retry is now unbounded in wall-clock terms for one narrow case: an engine that stays *connected* but never answers a pull with a `full` report will be re-polled every 4s for as long as the doc is open (previously it gave up after ~160s). A crash is covered — the first editor-facing call detects it and cancels the scope — but a fully idle user in front of a wedged-but-alive engine would keep the retry going. Routing the publisher's pulls through the self-heal path would close that too, but not without the reconnect cancelling its own caller, so it is deliberately left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
