### PR TITLE
⛔ SPIKE — DO NOT MERGE: measure the -Dintegration CI gate (#82a)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,13 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Run backend + protocol unit tests
-        run: ./gradlew test :backend:jvmTest :protocol:jvmTest
+        # SPIKE (#82): add -Dintegration=true to turn ON the integration gate that
+        # CI never passes today, to measure how many of the assumeTrue-gated
+        # integration methods actually execute + pass on a runner. The LSP
+        # integration tests additionally require KONSTRUCTOR_KOTLIN_LSP (a real
+        # engine), so those will still skip here — that asymmetry is part of the
+        # answer. DO NOT MERGE.
+        run: ./gradlew test :backend:jvmTest :protocol:jvmTest -Dintegration=true
 
       - name: Run e2e tests under Xvfb
         run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' ./gradlew :e2e:test -Pe2e


### PR DESCRIPTION
**⛔ SPIKE — DO NOT MERGE.** Prices #82(a): CI never passes `-Dintegration`, so ~14 `assumeTrue(-Dintegration)` methods silently skip and CI is green over them. This adds `-Dintegration=true` to the unit-test step so they actually run — measuring how much of the gate CI can execute and whether the runnable half reveals anything.

## The number this produces
Executed/passed/skipped counts for the integration methods, from the test report — **not** the job badge.

## Prediction (to test, not assert)
- `CompileAndExecuteIntegrationTest`, `SubprocessFailureTest` → should EXECUTE (need kotlinc/subprocess, not an engine).
- `BridgeLanguageServerIntegrationTest` → still SKIPS: it `assumeTrue`s on BOTH `-Dintegration` AND `KONSTRUCTOR_KOTLIN_LSP`, and there's no engine on the runner. That asymmetry is part of the answer.
- `KonstructionControllerSoakTest` → still skips (`-Dsoak` not set — deliberately left off; soak has a 2h timeout).

## Decision it prices
- Runnable integration tests **pass** → the gate is cheap to turn on for that subset (CompileAndExecute + subprocess); TAKE that much.
- Any **red** → a real bug the gate was hiding — the highest-value outcome.
- LSP integration stays skipped → the honest cost of engine-less CI: those need a runner-side engine (a bigger, separate decision), so `-Dintegration` alone does not make CI's LSP coverage real.

## Case AGAINST
Turning the gate on commits to KEEPING it green — a flaky integration red then blocks merges, and some of these touch the compile/execute subprocess which can be timing-sensitive. Worth confirming they're deterministic (run twice) before wiring it in for real.

## Does NOT establish
- #82(b) assertion-free e2e tests and #82(c) missing-baseline silent-pass — separate sub-findings, not touched here.
- Whether the runnable integration tests are STABLE (this is one run; failure counts on subprocess-shaped tests can vary — a second run is needed if any red appears).

Read the executed counts from the uploaded report; verdict reported separately.