### PR TITLE
ci: run integration tests so the compile+execute gate is real (part a of #82)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,12 @@ jobs:
       - name: Build shadowJar (produces the backend fat jar e2e tests run against)
         run: ./gradlew shadowJar
 
-      - name: Run backend + protocol unit tests
-        run: ./gradlew test :backend:jvmTest :protocol:jvmTest
+      - name: Run backend + protocol unit + integration tests
+        # -Dintegration=true runs the compile+execute and subprocess-failure
+        # integration tests (9 methods) that otherwise self-skip via assumeTrue.
+        # BridgeLanguageServerIntegrationTest stays skipped (its second gate needs
+        # a real kotlin-lsp engine, absent on the runner); soak stays off.
+        run: ./gradlew test :backend:jvmTest :protocol:jvmTest -Dintegration=true
 
       - name: Run e2e tests under Xvfb
         run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' ./gradlew :e2e:test -Pe2e


### PR DESCRIPTION
Refs #82 (part a of three — does not close the issue)

## What

`.github/workflows/ci.yaml` ran the unit-test step without `-Dintegration`, so the nine integration tests covering the core compile+execute and subprocess-failure paths self-skipped via `assumeTrue` on every PR — CI reported green over code that never ran. This adds `-Dintegration=true` to that step.

- `CompileAndExecuteIntegrationTest` (3) + `SubprocessFailureTest` (6) now execute in CI.
- `BridgeLanguageServerIntegrationTest` stays skipped: its second gate needs a real kotlin-lsp engine, absent on the runner.
- Soak stays off (`-Dsoak` unset; 2h timeout).

## Scope
One line in `ci.yaml` (plus an explanatory comment). This is **part (a)** of #82; part (b) the four assertion-free e2e tests and part (c) the silent missing-baseline pass are separate follow-ups. #82 stays open — parts (b) and (c) are not addressed here.

## Verification (local, build slot, on merged main including the #63 dep bumps)

**The nine tests pass deterministically** — ran the subset twice with the flag:
```
RUN 1: CompileAndExecuteIntegrationTest tests=3 failures=0 | SubprocessFailureTest tests=6 failures=0
RUN 2: CompileAndExecuteIntegrationTest tests=3 failures=0 | SubprocessFailureTest tests=6 failures=0
```

**The gate is demonstrated to bite** (a gate that has never rejected anything is indistinguishable from the no-op it replaces):
- *Without* the flag — the tests silently skip (the bug this fixes):
```
CompileAndExecuteIntegrationTest tests=3 skipped=3
SubprocessFailureTest           tests=6 skipped=6
=> BUILD SUCCESSFUL  (green while testing nothing)
```
- *With* the flag, after breaking one assertion on purpose (`assertEquals(SUCCESS, ...)` inverted to `FAILURE`) — the suite goes RED naming the test:
```
CompileAndExecuteIntegrationTest tests=3 failures=1
=> BUILD FAILED
```
The injected break was ephemeral (never committed) and reverted; the working tree ended clean with only `ci.yaml` changed, so there is no probe SHA to strip.

**Cost:** +~42s on the unit-test step (measured; the `shadowJar` step already runs first, so the resource prerequisites are in place).
