### PR TITLE
test(e2e): make the assertion-free gates actually measure something (#82 b+c)

### DIFF
--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -41,5 +41,18 @@ tasks.test {
     val jarFile = project(":backend")
         .layout.buildDirectory.file("libs/backend-all.jar")
     systemProperty("konstructor.jar", jarFile.get().asFile.absolutePath)
+    // Forward opt-in flags to the forked test JVM. Gradle does not propagate -D
+    // system properties or -P project properties to test workers automatically,
+    // so without this the `capture`/`updateBaselines` gates always read null.
+    //  - `capture`: run the assertion-free screenshot/manual capture tools.
+    //  - `updateBaselines`: on a missing baseline, write the captured actual as
+    //    the new baseline and skip (instead of failing).
+    // A bare `-Pcapture` / `-PupdateBaselines` (no value) is treated as opt-in.
+    listOf("capture", "updateBaselines").forEach { key ->
+        if (project.hasProperty(key) || System.getProperty(key) != null) {
+            val raw = (project.findProperty(key) as? String) ?: System.getProperty(key)
+            systemProperty(key, if (raw.isNullOrEmpty()) "true" else raw)
+        }
+    }
     useJUnit()
 }

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ManualVerificationTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ManualVerificationTest.kt
@@ -24,13 +24,27 @@ import com.monkopedia.ksrpc.toStub
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
  * Takes screenshots at every step to verify the full UI works.
- * Run with: DISPLAY=:99 ./gradlew :e2e:test -Pe2e --tests "*.ManualVerificationTest" --no-daemon
+ * Run with: DISPLAY=:99 ./gradlew :e2e:test -Pe2e -Pcapture --tests "*.ManualVerificationTest" --no-daemon
+ *
+ * This is a manual capture TOOL with no assertions, so on an ordinary run it
+ * must not masquerade as a passing test. It is gated behind `-Dcapture=true`
+ * (or `-Pcapture`) and SKIPs otherwise.
  */
 class ManualVerificationTest : BaseE2eTest() {
+
+    @Before
+    fun requireCaptureOptIn() {
+        assumeTrue(
+            "Set -Dcapture=true (or -Pcapture) to run the manual verification capture tool",
+            System.getProperty("capture") == "true"
+        )
+    }
 
     private val cubeScript = """
 val simpleCube by primitive {

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/MigrationVisualRegressionTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/MigrationVisualRegressionTest.kt
@@ -26,7 +26,9 @@ import com.monkopedia.ksrpc.toStub
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.WebSockets
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 import org.junit.Ignore
 import org.junit.Test
 
@@ -67,20 +69,34 @@ class MigrationVisualRegressionTest : BaseE2eTest() {
     }
 
     /**
-     * Capture the current full page and diff it against a named baseline. When
-     * no baseline exists yet, the actual is written to build/screenshots/ and
-     * the test asserts that fact (so a new baseline is a deliberate one-line add
-     * by copying the captured image into e2e/baselines/).
+     * Capture the current full page and diff it against a named baseline.
+     *
+     * A MISSING baseline is a FAILURE, not a silent pass — otherwise this gate
+     * measures nothing (issue #82c). The sanctioned way to establish a baseline
+     * is to run with `-PupdateBaselines` (or `-DupdateBaselines=true`): in that
+     * mode a missing baseline is written from the captured actual and the test
+     * SKIPs (so the next ordinary run compares against it). A plain run with a
+     * missing baseline FAILS.
      */
     private fun assertBaseline(name: String, maxDiffFraction: Double) {
         val png = page.screenshot(Page.ScreenshotOptions().setFullPage(true))
         val result = BaselineComparison.compare(png, name)
         if (!result.baselineExists) {
-            System.err.println(
-                "No baseline '$name' yet; captured actual at ${result.diffImagePath}. " +
-                    "Copy it into e2e/baselines/$name.png to establish it."
+            if (System.getProperty("updateBaselines") == "true") {
+                val target = BaselineComparison.baselineFor(name)
+                target.parentFile?.mkdirs()
+                target.writeBytes(png)
+                assumeTrue(
+                    "Established new baseline '$name' at ${target.absolutePath}; " +
+                        "re-run without -PupdateBaselines to compare against it.",
+                    false
+                )
+                return
+            }
+            fail(
+                "No baseline '$name' — run with -PupdateBaselines to establish it. " +
+                    "Captured actual is under build/screenshots/$name-actual.png."
             )
-            return
         }
         assertTrue(
             result.sameSize,

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/SaveFlowTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/SaveFlowTest.kt
@@ -22,6 +22,7 @@ import com.monkopedia.ksrpc.ktor.websocket.asWebsocketConnection
 import com.monkopedia.ksrpc.toStub
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.WebSockets
+import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
@@ -58,7 +59,7 @@ class SaveFlowTest : BaseE2eTest() {
         System.err.println("Workspace ID: $wsId")
 
         // Create konstruction and set content via API
-        runBlocking {
+        val konstruction = runBlocking {
             val env = ksrpcEnvironment { }
             val client = HttpClient { install(WebSockets) }
             val conn = client.asWebsocketConnection("${server.baseUrl}/konstructor", env)
@@ -70,6 +71,7 @@ class SaveFlowTest : BaseE2eTest() {
             val ks = service.konstruction(kon)
             ks.set(validScript)
             System.err.println("Created konstruction ${kon.id} and set content")
+            kon
         }
 
         // Reload again so Initializer picks up the konstruction
@@ -89,18 +91,30 @@ class SaveFlowTest : BaseE2eTest() {
         val vBefore = getVersion()
         page.evaluate("() => globalThis.__konstructor.actions.triggerSave('')")
 
-        try {
-            page.waitForFunction(
-                "(v) => globalThis.__konstructor.version > v",
-                vBefore,
-                com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(120000.0)
-            )
-            System.err.println("Save completed!")
-        } catch (e: Exception) {
-            System.err.println("Save timeout: ${e.message}")
-        }
+        // The version increment IS the "save happened" signal. If it never
+        // arrives, this throws and the test FAILS — a broken save must not pass.
+        page.waitForFunction(
+            "(v) => globalThis.__konstructor.version > v",
+            vBefore,
+            com.microsoft.playwright.Page.WaitForFunctionOptions().setTimeout(120000.0)
+        )
+        System.err.println("Save completed!")
 
         page.waitForTimeout(3000.0)
         screenshot("save-flow-after")
+
+        // Round-trip assertion: the saved content must be readable back via the
+        // API and match what we saved. Without this the save could "complete"
+        // (version bump) while persisting the wrong content and still pass.
+        runBlocking {
+            val env = ksrpcEnvironment { }
+            val client = HttpClient { install(WebSockets) }
+            val conn = client.asWebsocketConnection("${server.baseUrl}/konstructor", env)
+            val service = conn.defaultChannel().toStub<Konstructor, String>()
+            val ks = service.konstruction(konstruction)
+            val fetched = ks.fetch()
+            System.err.println("Fetched back ${fetched.length} chars after save")
+            assertEquals(validScript, fetched)
+        }
     }
 }

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ScreenshotTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ScreenshotTest.kt
@@ -15,13 +15,27 @@
  */
 package com.monkopedia.konstructor.e2e
 
+import org.junit.Assume.assumeTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
  * Captures screenshots of all major UI states for visual inspection.
  * Screenshots are saved to e2e/build/screenshots/.
+ *
+ * These are capture TOOLS, not assertions — they make no claim about behaviour,
+ * so on an ordinary run they must not masquerade as passing tests. They are
+ * gated behind `-Dcapture=true` (or `-Pcapture`) and SKIP otherwise.
  */
 class ScreenshotTest : BaseE2eTest() {
+
+    @Before
+    fun requireCaptureOptIn() {
+        assumeTrue(
+            "Set -Dcapture=true (or -Pcapture) to run screenshot capture tools",
+            System.getProperty("capture") == "true"
+        )
+    }
 
     @Test
     fun captureEmptyState() {


### PR DESCRIPTION
Fixes #82

Completes parts (b) and (c) of the "CI green signals that measure nothing" cluster. Part (a) — actually running the integration tests in CI — already shipped in #94, so this PR resolves the issue.

## 82(b) — four e2e tests that asserted nothing

**`SaveFlowTest.testTriggerSaveViaBridge`** — the save-completion signal was swallowed. The `page.waitForFunction("version > vBefore", …120 s)` was wrapped in `try { … "Save completed!" } catch { "Save timeout" }`, so a broken save waited two minutes, printed a line, and **passed**.
- Dropped the try/catch — the `waitForFunction` timeout now throws and fails the test (the version increment *is* the "save happened" signal).
- Added a round-trip assertion: after the save wait succeeds, re-open the ksrpc service, `ks.fetch()` the konstruction content back, and `assertEquals(validScript, fetched)`. Without this a save could bump the version while persisting the wrong content and still pass.

**`ScreenshotTest` (`captureEmptyState`, `captureMainScreen`) and `ManualVerificationTest` (`verifyFullUserFlow`)** — assertion-free capture tools that ran on every PR and always "passed". Gated behind `-Dcapture=true` / `-Pcapture` via `assumeTrue(...)` in a `@Before` (same pattern as the backend integration `-Dintegration` gate). They now **skip** instead of masquerading as passing tests, and remain available as capture tools (`-Pe2e -Pcapture`).

## 82(c) — a missing baseline passed silently

**`MigrationVisualRegressionTest.assertBaseline`** — a missing baseline did `System.err.println(...)` and `return`, i.e. a **pass**.
- A missing baseline now `fail()`s.
- The sanctioned escape hatch to establish a baseline is `-PupdateBaselines` (or `-DupdateBaselines=true`): in that mode a missing baseline is written from the captured actual and the test **skips** (so the next ordinary run compares against it). A plain run with a missing baseline **fails**.
- `e2e/build.gradle.kts` forwards the `capture` / `updateBaselines` opt-in flags to the forked test JVM (Gradle does not propagate `-D`/`-P` to test workers), mirroring the backend's integration-flag forwarding. A bare `-Pflag` (no value) counts as opt-in.

## Verification (group-A standard)

- **Compile — GREEN.** `./gradlew :e2e:compileTestKotlin` → `BUILD SUCCESSFUL` (only pre-existing deprecation/`!!` warnings in untouched files). Run through the shared buildslot.
- **82c demonstrate-to-fail — REASONED, not run locally.** The full e2e leg requires `:backend:shadowJar` (lib shadow jar + frontend wasm distribution) plus an Xvfb display, which is slow and finicky on this workstation and exceeds the foreground time budget; per the issue's own guidance I did **not** block on a full local e2e run. The break recipe for the reviewer / CI: temporarily `git mv e2e/baselines/01-empty-state.png e2e/baselines/01-empty-state.png.bak` and run `./gradlew :e2e:test -Pe2e --tests '*MigrationVisualRegressionTest*'`. Before this PR `emptyStateMatchesBaselineShape` took the `!result.baselineExists → return` branch and **passed**; after this PR the same missing baseline hits `fail("No baseline '01-empty-state' — run with -PupdateBaselines to establish it.")` and the test goes **RED**. Restore the file afterward. I am being explicit that this is reasoned from the diff, not a captured local red — CI's e2e leg on this PR is the intended green/red proof.
- **82b (SaveFlowTest) demonstrate-to-fail:** breaking the save path (or the persisted content) now makes either the `waitForFunction` timeout throw or the `assertEquals(validScript, fetched)` fail, where previously both were swallowed/absent — verifiable on the CI e2e leg.

The e2e leg on this PR exercises the newly-real gates end-to-end.
