### PR TITLE
refactor(backend): make cachingEnabled/compilerOpts real Config params

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/Config.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/Config.kt
@@ -40,12 +40,21 @@ class Config(
     val kotlinLspBinary: File? = (
         System.getenv("KONSTRUCTOR_KOTLIN_LSP")
             ?: System.getProperty("konstructor.kotlinLsp")
-        )?.let(::File)
+        )?.let(::File),
+    /**
+     * Whether the script host advertises STL caching to running scripts
+     * ([com.monkopedia.konstructor.lib.HostService.supportsCaching]). Turning it off
+     * makes every execution recompute its geometry, which is useful when diagnosing a
+     * stale-cache result.
+     */
+    val cachingEnabled: Boolean = true,
+    /**
+     * Extra flags handed to `kotlinc` when compiling a konstruction, ahead of
+     * [runtimeOpts]. Empty by default; whitespace-only values contribute nothing to the
+     * command line.
+     */
+    val compilerOpts: String = ""
 ) {
-    val cachingEnabled: Boolean
-        get() = true
-    val compilerOpts: String
-        get() = ""
     val runtimeOpts: String
         get() = "-cp ${LibsJar.getLibsJar(this).absolutePath} -J-Xmx4g -J-Xms4g"
     val json: Json = Json {

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/CompileTask.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/CompileTask.kt
@@ -46,7 +46,7 @@ class CompileTask(private val config: Config, private val input: File, private v
     ).use { executeThread ->
         val callSign = coroutineContext[CallSign.Key]
         runInterruptible(executeThread + (callSign ?: EmptyCoroutineContext)) {
-            val opts = "${config.compilerOpts} ${config.runtimeOpts}"
+            val opts = compileOpts(config.compilerOpts, config.runtimeOpts)
             val command = "kotlinc $opts -d ${output.absolutePath} ${input.absolutePath}"
             val (stdOut, stdError, result) = executeAndWait(command)
             if (result == 0) {
@@ -68,6 +68,17 @@ class CompileTask(private val config: Config, private val input: File, private v
     companion object {
         @OptIn(DelicateCoroutinesApi::class)
         private val hauler = hauler().asAsync(GlobalScope)
+
+        /**
+         * The `kotlinc` flag string: [Config.compilerOpts] ahead of [Config.runtimeOpts],
+         * with blank entries dropped so an unset [Config.compilerOpts] contributes no
+         * argument (and no stray leading space) to the command line.
+         */
+        internal fun compileOpts(compilerOpts: String, runtimeOpts: String): String =
+            listOf(compilerOpts, runtimeOpts)
+                .filter { it.isNotBlank() }
+                .joinToString(" ")
+
         private val errorRegex = Regex("^(.*):([0-9]+):([0-9]+): (.*)$")
         private val headerLines = KcsgScript.HEADER.split("\n").size
         private val footerLines = KcsgScript.FOOTER.split("\n").size

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/ConfigTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/ConfigTest.kt
@@ -18,6 +18,7 @@ package com.monkopedia.konstructor
 import com.monkopedia.konstructor.common.Space
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 
@@ -53,5 +54,20 @@ class ConfigTest {
     fun testCachingEnabled() {
         val config = Config()
         assertTrue(config.cachingEnabled)
+    }
+
+    @Test
+    fun testCachingEnabledIsOverridable() {
+        assertFalse(Config(cachingEnabled = false).cachingEnabled)
+    }
+
+    @Test
+    fun testCompilerOptsDefaultsToEmpty() {
+        assertEquals("", Config().compilerOpts)
+    }
+
+    @Test
+    fun testCompilerOptsIsOverridable() {
+        assertEquals("-Xfoo", Config(compilerOpts = "-Xfoo").compilerOpts)
     }
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/hostservices/ScriptHostImplTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/hostservices/ScriptHostImplTest.kt
@@ -15,9 +15,11 @@
  */
 package com.monkopedia.konstructor.hostservices
 
+import com.monkopedia.konstructor.Config
 import com.monkopedia.konstructor.testutil.TestEnvironment
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -53,6 +55,20 @@ class ScriptHostImplTest {
     fun testSupportsCaching() = runBlocking {
         val result = host.supportsCaching(Unit)
         assertTrue(result)
+        Unit
+    }
+
+    @Test
+    fun testSupportsCachingFollowsConfig() = runBlocking {
+        val config = Config(env.tempDir, cachingEnabled = false)
+        val disabled = ScriptHostImpl(
+            scriptManager = ScriptManager(config),
+            config = config,
+            workspaceId = "ws1",
+            konstructionId = "k1",
+            cacheDir = cacheDir
+        )
+        assertFalse(disabled.supportsCaching(Unit))
         Unit
     }
 

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/CompileTaskTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/CompileTaskTest.kt
@@ -25,6 +25,17 @@ import kotlinx.coroutines.runBlocking
 
 class CompileTaskTest {
     @Test
+    fun `compile opts omit a blank compilerOpts entirely`() {
+        assertEquals("-cp lib.jar", CompileTask.compileOpts("", "-cp lib.jar"))
+        assertEquals("-cp lib.jar", CompileTask.compileOpts("   ", "-cp lib.jar"))
+    }
+
+    @Test
+    fun `compile opts put compilerOpts ahead of runtimeOpts`() {
+        assertEquals("-Xfoo -cp lib.jar", CompileTask.compileOpts("-Xfoo", "-cp lib.jar"))
+    }
+
+    @Test
     fun `parse sample kotlinc output`() {
         val offset = KcsgScript.HEADER.split("\n").size
         val testOutput = """


### PR DESCRIPTION
Fixes #98

## What

`Config.cachingEnabled` and `Config.compilerOpts` were read-only getters returning a fixed literal, so `Config` advertised two knobs that nothing could set. `compilerOpts` was worse than inert: it always contributed an empty string to `"${compilerOpts} ${runtimeOpts}"`, so every `kotlinc` invocation was built with a dead leading space.

Both are now constructor parameters with their current values as defaults — the same shape `executeTimeout` and `kotlinLspBinary` already use — and the flag string is assembled by dropping blank entries, so an unset `compilerOpts` contributes no argument at all.

The issue offered two options: (a) inline the constants and delete the properties, or (b) promote them to real parameters. This takes (b). `cachingEnabled = false` is a genuinely useful switch when diagnosing a stale STL cache, and `compilerOpts` is the natural place to pass an extra `kotlinc` flag; deleting them would remove the only place either belongs. Behaviour at the defaults is unchanged.

## Demonstrated RED

Each new test fails without the production change:

- `CompileTask.compileOpts` is extracted so the flag string is directly assertable. Restoring the old `"${compilerOpts} ${runtimeOpts}"` interpolation reproduces the defect exactly:
  `compile opts omit a blank compilerOpts entirely -> expected:<[]-cp lib.jar> but was:<[ ]-cp lib.jar>`
- `ScriptHostImplTest.testSupportsCachingFollowsConfig` builds a host from `Config(cachingEnabled = false)` and asserts `supportsCaching` reports `false`, so the flag is proven wired through `HostService` rather than hardcoded. Against the old constant getter it does not even compile — there is no such parameter.
- `ConfigTest` covers both defaults and both overrides.

## Verification

`./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` — **143 tests, 0 failures, 6 skipped** across 28 freshly written result XMLs (old XML deleted first; `:backend:jvmTest` executed, not `UP-TO-DATE`). Green re-confirmed after reverting the RED control.

## Notes for the reviewer

- `main` is unprotected here, so `--auto` is not a CI gate. Please poll `gh pr checks 98` to a completed SUCCESS yourself before merging, then plain `--squash --delete-branch`.
- Params are appended after `kotlinLspBinary`, so no positional caller changes meaning (only `dataDirFile` is ever passed positionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)