### PR TITLE
refactor(backend): extract the shared info.json CRUD scaffolding

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/InfoStore.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/InfoStore.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.monkopedia.konstructor
+
+import java.io.File
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+
+/**
+ * On-disk layout shared by every item store: one directory per item, each holding an
+ * [INFO_JSON] describing it. [KonstructorImpl] keeps [com.monkopedia.konstructor.common.Space]
+ * dirs under the data dir; [WorkspaceImpl] keeps
+ * [com.monkopedia.konstructor.common.KonstructionInfo] dirs under a workspace.
+ *
+ * These rules are load-bearing persistence behaviour, so they live in one place rather
+ * than being restated per service.
+ */
+internal const val INFO_JSON = "info.json"
+
+/**
+ * Every immediate subdirectory of [this] that holds an [INFO_JSON], decoded as [T].
+ *
+ * Non-directories and directories with no [INFO_JSON] are skipped (a half-created or
+ * hand-made directory must not fail the whole listing), and an unreadable parent yields
+ * an empty list.
+ */
+internal inline fun <reified T> File.listInfo(json: Json): List<T> =
+    listFiles()?.mapNotNull { child ->
+        if (!child.isDirectory) return@mapNotNull null
+        val infoFile = File(child, INFO_JSON)
+        if (!infoFile.exists()) return@mapNotNull null
+        infoFile.inputStream().use { input ->
+            json.decodeFromStream<T>(input)
+        }
+    } ?: emptyList()
+
+/**
+ * The lowest non-negative integer, as a string, that is not in [usedIds].
+ *
+ * Membership is tested against a hash set, so allocating an id is linear in the number
+ * of existing items rather than quadratic.
+ */
+internal fun firstFreeId(usedIds: Collection<String>): String {
+    val used = usedIds.toHashSet()
+    var id = 0
+    while (used.contains(id.toString())) {
+        id++
+    }
+    return id.toString()
+}
+
+/**
+ * Claim [targetInfo] for a new item and write [value] to it.
+ *
+ * Both the file and its directory must be absent — an existing directory means the id is
+ * taken even when its [INFO_JSON] was never written — otherwise this throws
+ * [IllegalArgumentException] naming [id].
+ */
+internal inline fun <reified T> writeNewInfo(targetInfo: File, id: String, json: Json, value: T) {
+    if (targetInfo.exists() || targetInfo.parentFile.exists()) {
+        throw IllegalArgumentException("$id has been used already")
+    }
+    targetInfo.parentFile.mkdirs()
+    targetInfo.outputStream().use { output ->
+        json.encodeToStream(value, output)
+    }
+}

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructorImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructorImpl.kt
@@ -40,8 +40,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.decodeFromStream
-import kotlinx.serialization.json.encodeToStream
 
 @OptIn(DelicateCoroutinesApi::class)
 class KonstructorImpl(private val config: Config) :
@@ -66,14 +64,7 @@ class KonstructorImpl(private val config: Config) :
     }
 
     override suspend fun list(u: Unit): List<Space> = callContext("list") {
-        config.dataDir.listFiles()?.mapNotNull {
-            if (!it.isDirectory) return@mapNotNull null
-            val infoFile = File(it, "info.json")
-            if (!infoFile.exists()) return@mapNotNull null
-            infoFile.inputStream().use { input ->
-                config.json.decodeFromStream<Space>(input)
-            }
-        } ?: emptyList()
+        config.dataDir.listInfo<Space>(config.json)
     }
 
     override suspend fun konstruction(id: Konstruction): KonstructionService =
@@ -97,24 +88,12 @@ class KonstructorImpl(private val config: Config) :
         val newItemWithId = newItem.copy(
             id = newItem.id.ifEmpty { generateId() }
         )
-        val targetInfo = newItemWithId.infoFile
-        if (targetInfo.exists() || targetInfo.parentFile.exists()) {
-            throw IllegalArgumentException("${newItemWithId.id} has been used already")
-        }
-        targetInfo.parentFile.mkdirs()
-        targetInfo.outputStream().use { output ->
-            config.json.encodeToStream(newItemWithId, output)
-        }
+        writeNewInfo(newItemWithId.infoFile, newItemWithId.id, config.json, newItemWithId)
         newItemWithId
     }
 
     private suspend fun generateId(): String = callContext("generateId") {
-        val usedIds = list().map { it.id }
-        var id = 0
-        while (usedIds.contains(id.toString())) {
-            id++
-        }
-        id.toString()
+        firstFreeId(list().map { it.id })
     }
 
     override suspend fun delete(item: Space): Unit = callContext("delete") {
@@ -134,5 +113,5 @@ class KonstructorImpl(private val config: Config) :
     fun getInputStream(target: String): InputStream = File(config.dataDir, target).inputStream()
 
     private val Space.infoFile: File
-        get() = File(File(config.dataDir, id), "info.json")
+        get() = File(File(config.dataDir, id), INFO_JSON)
 }

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/WorkspaceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/WorkspaceImpl.kt
@@ -36,14 +36,7 @@ class WorkspaceImpl(private val config: Config, private val workspaceId: String)
         get() = "Workspace"
 
     override suspend fun list(u: Unit): List<Konstruction> = callContext("list") {
-        workspaceDir.listFiles()?.mapNotNull {
-            if (!it.isDirectory) return@mapNotNull null
-            val infoFile = File(it, "info.json")
-            if (!infoFile.exists()) return@mapNotNull null
-            infoFile.inputStream().use { input ->
-                config.json.decodeFromStream<KonstructionInfo>(input).konstruction
-            }
-        } ?: emptyList()
+        workspaceDir.listInfo<KonstructionInfo>(config.json).map { it.konstruction }
     }
 
     override suspend fun getName(u: Unit): String = callContext("getName") {
@@ -68,25 +61,16 @@ class WorkspaceImpl(private val config: Config, private val workspaceId: String)
         val newItemWithId = newItem.copy(
             id = newItem.id.ifEmpty { generateId() }
         )
-        val targetInfo = newItemWithId.infoFile
-        if (targetInfo.exists() || targetInfo.parentFile.exists()) {
-            throw IllegalArgumentException("${newItemWithId.id} has been used already")
-        }
-        targetInfo.parentFile.mkdirs()
-        targetInfo.outputStream().use { output ->
-            config.json.encodeToStream(KonstructionInfo(newItemWithId, CLEAN, emptyList()), output)
-        }
+        writeNewInfo(
+            newItemWithId.infoFile,
+            newItemWithId.id,
+            config.json,
+            KonstructionInfo(newItemWithId, CLEAN, emptyList())
+        )
         newItemWithId
     }
 
-    private suspend fun generateId(): String {
-        val usedIds = list().map { it.id }
-        var id = 0
-        while (usedIds.contains(id.toString())) {
-            id++
-        }
-        return id.toString()
-    }
+    private suspend fun generateId(): String = firstFreeId(list().map { it.id })
 
     override suspend fun delete(item: Konstruction): Unit = callContext("delete") {
         val targetInfo = item.infoFile
@@ -97,7 +81,7 @@ class WorkspaceImpl(private val config: Config, private val workspaceId: String)
     }
 
     private val workspaceDir = File(config.dataDir, workspaceId)
-    private val infoFile = File(workspaceDir, "info.json")
+    private val infoFile = File(workspaceDir, INFO_JSON)
     private val Konstruction.infoFile: File
-        get() = File(File(workspaceDir, id), "info.json")
+        get() = File(File(workspaceDir, id), INFO_JSON)
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/InfoStoreTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/InfoStoreTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.monkopedia.konstructor
+
+import com.monkopedia.konstructor.common.Space
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import org.junit.After
+import org.junit.Before
+
+class InfoStoreTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var root: File
+
+    @Before
+    fun setUp() {
+        root = kotlin.io.path.createTempDirectory("info-store-test-").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+    }
+
+    private fun writeSpace(id: String, name: String = "space $id") {
+        val dir = File(root, id).also { it.mkdirs() }
+        File(dir, INFO_JSON).outputStream().use { output ->
+            json.encodeToStream(Space(id = id, name = name), output)
+        }
+    }
+
+    @Test
+    fun listInfoDecodesEveryItemDirectory() {
+        writeSpace("0")
+        writeSpace("1")
+        assertEquals(
+            listOf("0", "1"),
+            root.listInfo<Space>(json).map { it.id }.sorted()
+        )
+    }
+
+    @Test
+    fun listInfoSkipsLooseFilesAndDirectoriesWithoutInfo() {
+        writeSpace("0")
+        File(root, "stray.txt").writeText("not a workspace")
+        File(root, "half-created").mkdirs()
+        assertEquals(listOf("0"), root.listInfo<Space>(json).map { it.id })
+    }
+
+    @Test
+    fun listInfoOnMissingDirectoryIsEmpty() {
+        assertEquals(emptyList(), File(root, "nope").listInfo<Space>(json))
+    }
+
+    @Test
+    fun firstFreeIdFillsTheLowestGap() {
+        assertEquals("0", firstFreeId(emptyList()))
+        assertEquals("1", firstFreeId(listOf("0")))
+        assertEquals("2", firstFreeId(listOf("0", "1", "3")))
+        // Non-numeric ids never block an allocation.
+        assertEquals("0", firstFreeId(listOf("named", "other")))
+    }
+
+    @Test
+    fun writeNewInfoWritesTheItemAndRejectsAReusedId() {
+        val target = File(File(root, "0"), INFO_JSON)
+        writeNewInfo(target, "0", json, Space(id = "0", name = "first"))
+        val written = target.inputStream().use { json.decodeFromStream<Space>(it) }
+        assertEquals("first", written.name)
+
+        val failure = assertFailsWith<IllegalArgumentException> {
+            writeNewInfo(target, "0", json, Space(id = "0", name = "second"))
+        }
+        assertEquals("0 has been used already", failure.message)
+    }
+
+    @Test
+    fun writeNewInfoRejectsAnIdWhoseDirectoryExistsWithoutInfo() {
+        File(root, "7").mkdirs()
+        assertFailsWith<IllegalArgumentException> {
+            writeNewInfo(File(File(root, "7"), INFO_JSON), "7", json, Space(id = "7", name = "x"))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #97

## What

`KonstructorImpl` (over `Space`, under the data dir) and `WorkspaceImpl` (over `KonstructionInfo`, under a workspace dir) are parallel services over the same on-disk contract — one directory per item, each holding an `info.json` — and each restated the same three pieces of it. New `InfoStore.kt` holds them once:

| helper | replaces |
| --- | --- |
| `File.listInfo<T>(json)` | the identical "skip non-directories, skip directories with no `info.json`, stream-decode the rest" scan in both `list()` implementations |
| `firstFreeId(usedIds)` | both byte-identical `generateId()` bodies |
| `writeNewInfo(target, id, json, value)` | the "file **or** its directory already present ⇒ id taken" guard, `mkdirs()`, and encode in both `create()` implementations |

`WorkspaceImpl` still supplies its own post-decode mapping (`KonstructionInfo -> .konstruction`) and its workspace-id guard; only the shared scaffolding moved.

The complexity note from the issue is fixed as part of the fold: both copies tested membership with `usedIds.contains(...)` against a `List`, so allocating an id was O(n²). `firstFreeId` hashes the ids once, making it linear.

## Behaviour

Unchanged. The existing `KonstructorImplTest` / `WorkspaceImplTest` are the behaviour-preservation evidence and pass untouched.

## Tests

`InfoStoreTest` asserts the extracted rules directly, including two the scan depends on that nothing covered before: a loose file in the container, and a half-created directory with no `info.json`, are both **skipped** rather than failing the whole listing.

**Mutation control** — the tests bite. Starting `firstFreeId` at 1 and dropping the missing-`info.json` guard produced:
```
firstFreeIdFillsTheLowestGap                    expected:<[0]> but was:<[1]>
listInfoSkipsLooseFilesAndDirectoriesWithoutInfo java.io.FileNotFoundException: .../half-created/info.json
```

## Verification

`./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` — **143 tests, 0 failures, 6 skipped**, fresh result XML (old deleted first, `:backend:jvmTest` executed rather than `UP-TO-DATE`).

## One thing the reviewer should know: a latent flake I hit and did not ship

An earlier revision of `InfoStoreTest` carried a wall-clock test asserting the linear id allocation finished 50k ids inside 5s. With it present, `ScopedShipperTest.requestPickupDelegatesToWrappedShipper` failed **2 times in 9 full-suite runs** with `UncaughtExceptionsBeforeTest` — an exception escaping some *earlier* test's coroutine and being attributed to the next `runTest`. Measurements:

| tree | failures / runs |
| --- | --- |
| this branch **with** the timing test | 2 / 9 |
| this branch **without** the timing test | 0 / 6 |
| this branch, production change only, no new tests | 0 / 6 |
| unrelated control branch off the same base | 0 / 6 |

I dropped the timing test — it is environment-dependent and it is the only variable that co-occurs with the failures. **That is correlation, not proof**: 0/6 cannot rule out a ~20% rate, so I am not claiming the timing test causes it. What the data does show is that the flake is not in the refactor. The underlying fragility (a leaked async exception landing on an unrelated `runTest`) is pre-existing and I am filing it separately.

## Notes for the reviewer

`main` is unprotected here, so `--auto` is not a CI gate — please poll `gh pr checks` to a completed SUCCESS yourself before merging, then plain `--squash --delete-branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)