### PR TITLE
feat(frontend): default lspEnabled to ON (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The backend's `shadowJar` task orchestrates the full build:
 - Koin for dependency injection with ViewModels (`koin-compose-viewmodel`).
 - State management via Kotlin StateFlows, collected in Composables via `collectAsState()`.
 - JsBridge (formerly TestBridge) pattern for Playwright e2e testing: exposes app state to `globalThis.__konstructor` since Compose renders to a WebGL canvas (no DOM elements for Playwright selectors).
-- **LSP**: a kcsg-aware language server (completion/hover/pull-diagnostics) is wired through `backend/src/jvmMain/.../lsp/` (a `BridgeLanguageServer` fronting a standalone kotlin-lsp/intellij-server engine spawned via `KONSTRUCTOR_KOTLIN_LSP`) and the frontend editor's LSP client. Opt-in via a Settings toggle.
+- **LSP**: a kcsg-aware language server (completion/hover/pull-diagnostics) is wired through `backend/src/jvmMain/.../lsp/` (a `BridgeLanguageServer` fronting a standalone kotlin-lsp/intellij-server engine spawned via `KONSTRUCTOR_KOTLIN_LSP`) and the frontend editor's LSP client. On by default since 2026-08-21; opt out via a Settings toggle.
 
 ## Frontend Structure (src/wasmJsMain/)
 

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -119,7 +119,8 @@ class KonstructionServiceImpl(
             // param, so its publishDiagnostics channel rides the same WebSocket) is
             // stashed and the bridge forwards real kcsg-aware diagnostics to it.
             //
-            // Still wholly flag-gated on the frontend (lspEnabled, default OFF) and the
+            // Still wholly flag-gated on the frontend (lspEnabled, default ON since
+            // 2026-08-21 — the flag still exists, only its default moved) and the
             // bridge degrades to an inert server when no kotlin-lsp binary is configured
             // (CI), so the absence of the engine never crashes konstructor.
             BridgeLanguageServer(config, workspaceId, id, client)

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/LspPipeTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/LspPipeTest.kt
@@ -21,6 +21,7 @@ import com.monkopedia.ksrpc.ktor.websocket.asWebsocketConnection
 import com.monkopedia.ksrpc.toStub
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.WebSockets
+import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
@@ -38,9 +39,12 @@ import org.junit.Test
  *
  * This test therefore asserts the flag-ON path is wired and harmless WITHOUT a
  * binary: the editor mounts, the session establishes, the app stays on the main
- * screen, and no spurious diagnostics appear. The flag-OFF behavior (editor
- * byte-for-byte unchanged) is covered by the rest of the suite running with the
- * default-off flag.
+ * screen, and no spurious diagnostics appear.
+ *
+ * Flag-OFF used to be covered implicitly, by the whole suite running under the
+ * default-off flag. **That stopped being true when the default flipped to ON**
+ * (2026-08-21), so [testEditorWorksWithLspFlagOff] now covers it explicitly rather
+ * than the coverage disappearing silently along with the default.
  */
 class LspPipeTest : BaseE2eTest() {
 
@@ -116,6 +120,60 @@ class LspPipeTest : BaseE2eTest() {
         assert(count == 0) {
             "With no kotlin-lsp binary on CI the bridge is inert; expected 0 " +
                 "diagnostics, got count=$count"
+        }
+    }
+
+    @Test
+    fun testEditorWorksWithLspFlagOff() {
+        loadApp()
+        waitForBridge()
+
+        bridgeAction("createWorkspace", "LspOffWs")
+        waitForState(
+            "globalThis.__konstructor.state.workspaceIds && " +
+                "globalThis.__konstructor.state.workspaceIds.length >= 1"
+        )
+        val wsId = bridgeStateStringList("workspaceIds").first()
+
+        val konId = runBlocking {
+            val env = ksrpcEnvironment { }
+            val client = HttpClient { install(WebSockets) }
+            val conn = client.asWebsocketConnection("${server.baseUrl}/konstructor", env)
+            val service = conn.defaultChannel().toStub<Konstructor, String>()
+            val workspace = service.get(wsId)
+            val kon = workspace.create(
+                Konstruction(name = "LspOffTest", workspaceId = wsId, id = "")
+            )
+            service.konstruction(kon).set(validScript)
+            kon.id
+        }
+
+        page.reload()
+        waitForBridge()
+        waitForMainScreen()
+
+        // Explicitly OFF. Since 2026-08-21 the default is ON, so this is the only place
+        // the flag-off editor is exercised — it is not the ambient state of the suite
+        // any more.
+        bridgeAction("setLspEnabled", "false")
+        assertEquals(false, bridgeStateBoolean("lspEnabled"))
+
+        bridgeAction("setCodePaneMode", "EDITOR")
+        bridgeActionNoWait("selectKonstruction", konId)
+        page.waitForTimeout(5000.0)
+
+        // With the flag off the editor takes the pre-LSP path: no lsp() call, no
+        // languageServerSupport, and therefore nothing can publish diagnostics.
+        waitForMainScreen()
+        assertEquals(false, bridgeStateBoolean("lspEnabled"))
+        val count = (
+            page.evaluate(
+                "() => (globalThis.__konstructor.lspDiagnostics && " +
+                    "globalThis.__konstructor.lspDiagnostics.count) || 0"
+            ) as? Number
+            )?.toInt() ?: 0
+        assert(count == 0) {
+            "With lspEnabled=false nothing should publish diagnostics, got count=$count"
         }
     }
 }

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ThemeAndKeymapTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/ThemeAndKeymapTest.kt
@@ -131,19 +131,24 @@ class ThemeAndKeymapTest : BaseE2eTest() {
     fun testLspEnabledToggle() {
         setupWorkspaceWithCode()
 
-        // Default is opt-out: LSP off, so the editor is unchanged for users who
-        // never enable it.
-        assertEquals(false, bridgeStateBoolean("lspEnabled"))
-
-        // The Settings switch (and its bridge action) flips the persisted flag;
-        // the snapshot reflects it so the toggle shows the right state.
-        bridgeAction("setLspEnabled", "true")
-        page.waitForTimeout(3000.0)
+        // Default is opt-OUT as of 2026-08-21: a browser with nothing stored gets
+        // LSP on. Config.isKotlinLspAvailable is still the second gate, so on a
+        // runner with no kotlin-lsp binary the flag being true changes nothing the
+        // user can see — which is exactly why this asserts the flag and not an
+        // editor behaviour.
         assertEquals(true, bridgeStateBoolean("lspEnabled"))
 
+        // The Settings switch (and its bridge action) flips the persisted flag;
+        // the snapshot reflects it so the toggle shows the right state. Toggling
+        // off first, then back, leaves the stored value matching the default so
+        // this test does not change what a later test sees.
         bridgeAction("setLspEnabled", "false")
         page.waitForTimeout(3000.0)
         assertEquals(false, bridgeStateBoolean("lspEnabled"))
+
+        bridgeAction("setLspEnabled", "true")
+        page.waitForTimeout(3000.0)
+        assertEquals(true, bridgeStateBoolean("lspEnabled"))
     }
 
     @Test

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/BridgeStateSnapshot.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/BridgeStateSnapshot.kt
@@ -47,7 +47,9 @@ data class AppStateSnapshot(
     val codePaneMode: String = "EDITOR",
     val editorTheme: String = "DRACULA",
     val keymap: String = "VIM",
-    val lspEnabled: Boolean = false,
+    // Matches SettingsViewModel's default so a snapshot built before the settings
+    // flow emits does not momentarily report the opposite of the real setting.
+    val lspEnabled: Boolean = true,
     val screen: String = "loading",
     val konstructionCount: Int = 0,
     val konstructionNames: List<String> = emptyList(),

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/settings/SettingsPane.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/ui/settings/SettingsPane.kt
@@ -94,7 +94,8 @@ fun SettingsPane(modifier: Modifier = Modifier) {
 
         // Code intelligence via the kotlin-lsp language server: completion,
         // hover, signature help, and live error diagnostics in the editor.
-        // Opt-in; requires the server to have an LSP engine configured.
+        // On by default since 2026-08-21 (opt-OUT); still requires the server to have
+        // an LSP engine configured, so with no engine this switch changes nothing.
         SettingSwitchRow(
             label = "Code completion & errors (LSP)",
             checked = lspEnabled,

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/SettingsViewModel.kt
@@ -82,10 +82,21 @@ class SettingsViewModel {
     private val vimDisplayLineMotionStore =
         PersistedStateFlow.boolean("vimDisplayLineMotion", false)
 
-    // LSP editor support (epic #35). Default OFF: with this off the editor
-    // behaves byte-for-byte as before — no lsp() call, no languageServerSupport.
+    // LSP editor support (epic #35). Default ON as of 2026-08-21, on the owner's
+    // ruling: "sure, flip it on, we have basically no users, so no real harm".
+    // That is a BLAST-RADIUS judgement, not a verdict that the LSP is good enough
+    // for everyone — the PoC found accurate kcsg diagnostics with no false
+    // positives, but nobody has a month of real editing behind it and the cost
+    // figures (~2GB heap, ~120s cold index, ~8s didOpen->diagnostics) are PoC
+    // numbers. If konstructor acquires real users the premise is gone and this
+    // gets re-asked rather than silently carried forward.
+    //
+    // This is the DEFAULT only. It applies where nothing is stored; anyone who has
+    // already toggled the setting keeps their stored value in either direction.
+    // Config.isKotlinLspAvailable remains the second gate, so a missing kotlin-lsp
+    // binary still means the feature is inert and the editor behaves as before.
     private val lspEnabledStore =
-        PersistedStateFlow.boolean("lspEnabled", false)
+        PersistedStateFlow.boolean("lspEnabled", true)
     private val showCodeLeftStore =
         PersistedStateFlow.boolean("showCodeLeft", false)
     private val showFpsStore =


### PR DESCRIPTION
Refs #35 — the LSP epic stays open; this lands one decision from it.

## The ruling

> *"sure, flip it on, we have basically no users, so no real harm"* — 2026-08-21

This settles go-live decision 2 from 2026-06-04, which had never actually been ruled on: the feature shipped OFF because that is how the flag was built, not because anyone chose it.

**The reasoning is the ruling, not a justification attached to it.** He judged the **blast radius**, not the feature. What was unmeasured when he answered, and still is: the PoC found accurate kcsg diagnostics with zero false positives, but nobody has a month of real editing behind it, and the cost figures are PoC numbers (~2GB heap, ~120s cold index, ~4s warm init, ~8s didOpen→diagnostics, 0.2–2.2s completion).

So the condition is his own: **if konstructor acquires real users, the basis for this decision is gone and it gets re-asked** — not silently carried forward. That is written into the comment above the flag, not just here, because the person who finds this in six months will otherwise see "owner approved default-on" without the premise it rested on. One flag, one feature; this is not a licence to flip other defaults.

## What changes, and what does not

`SettingsViewModel.kt`: `PersistedStateFlow.boolean("lspEnabled", false)` → `true`.

**That is the DEFAULT only, and the default applies only where nothing is stored.** `lspEnabled` is a persisted per-user setting:

| who | before | after |
| --- | --- | --- |
| explicitly turned LSP **off** | off | **off** — unchanged |
| explicitly turned LSP **on** | on | **on** — unchanged |
| never touched it / fresh browser | off | **on** |

If the intent were "everyone gets LSP now", a default change does not deliver that — something would have to clear stored values, which is more invasive and **not authorised**. The intent taken is "new users get it", for which this is exactly right and nothing more is needed. Worth stating plainly rather than leaving as "probably academic", because that is the reasoning that stops people checking.

`Config.isKotlinLspAvailable` remains the second gate: with no `kotlin-lsp` binary configured or present, the backend never spawns the subprocess and the editor behaves exactly as it does without LSP. CI has no binary, so on the runner the flag being `true` changes nothing observable — which is precisely why the e2e coverage asserts the flag rather than an editor behaviour.

## Why a test is edited alongside a behaviour change

`ThemeAndKeymapTest.testLspEnabledToggle` **asserted the old default, and the default is the thing being changed.** That is not a test bent to fit the code — a reviewer seeing a test move next to a behaviour change should ask, and the answer is here. It now also toggles off and back on, so the stored value it leaves behind matches the new default and it does not change what a later test sees.

**RED control, because "the test passes" is not evidence that it measures the default.** With the new test in place and the production default reverted to `false`, the full wasm bundle and shadow JAR rebuilt:

```
com.monkopedia.konstructor.e2e.ThemeAndKeymapTest  tests 1  failures 1
FAILED testLspEnabledToggle | java.lang.AssertionError: expected:<true> but was:<false>
```

The default was then restored to `true` and the restore verified in the source before committing.

## Verification

Local, fleet build slot, old result XML deleted with the find form first:

- `./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true shadowJar` — **backend 132 tests / 0 failures / 6 skipped** (27 XML), **protocol 17 / 0 / 0** (2 XML).
- `./gradlew :e2e:test -Pe2e --tests "*ThemeAndKeymapTest*"` under Xvfb with the Mesa EGL override — **4 tests / 0 failures / 0 skipped**; `testLspEnabledToggle` ran for 13.7s. Run locally on purpose: the assertion being changed is an e2e one, and it should not be CI that discovers a problem with it.

## Notes for the reviewer

- `main` is unprotected here, so `--auto` is not a CI gate — please poll `gh pr checks` to a completed SUCCESS yourself, then plain `--squash --delete-branch`.
- Known-flaky gate on the way: `ExecUtil`'s stderr pump leaks an `IOException` that lands on an unrelated `runTest` under `-Dintegration=true` (#101). If CI goes red on `ScopedShipperTest`, that is it, and it is not this change. Please confirm the failure signature against #101 rather than assuming.
- Deployment is out of scope. :8001 is manual and the owner's domain; nothing here touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)