### PR TITLE
fix(tasks): stop ExecProcess leaking IOException from the stderr pump

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecUtil.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecUtil.kt
@@ -130,6 +130,14 @@ object ExecUtil {
                     // built on are closed when the process exits. Leave `connection`
                     // uncompleted — callers already handle a process that died before it
                     // could be attached to.
+                    //
+                    // Logged, unlike the stderr pump, because the two failures are not
+                    // equally expected here. `connection` is awaited in one place
+                    // (ScriptManager, inside withTimeout), so a GENUINE I/O failure while
+                    // attaching would otherwise present only as a timeout with the cause
+                    // discarded and no trace anywhere. Debug level keeps the ordinary
+                    // shutdown case from being noise.
+                    hauler.debug("Process streams closed before the channel attached: ${t.message}")
                 }
             }
             parentScope.launch {

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecUtil.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecUtil.kt
@@ -18,6 +18,7 @@ package com.monkopedia.konstructor.tasks
 import com.monkopedia.hauler.CallSign
 import com.monkopedia.hauler.asAsync
 import com.monkopedia.hauler.debug
+import com.monkopedia.hauler.error
 import com.monkopedia.hauler.hauler
 import com.monkopedia.hauler.info
 import com.monkopedia.ksrpc.ErrorListener
@@ -25,10 +26,12 @@ import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.sockets.asConnection
 import java.io.BufferedReader
+import java.io.IOException
 import java.io.InputStreamReader
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -67,8 +70,25 @@ object ExecUtil {
 
     class ExecProcess(private val proc: Process) {
         private val parentJob = SupervisorJob()
+
+        /**
+         * Nothing from this process's plumbing may reach the global handler.
+         *
+         * [parentJob] is a [SupervisorJob] with no handler of its own, so a child that
+         * throws does not cancel its siblings — it goes straight to the JVM's default
+         * uncaught-exception handler instead, where nothing connects it back to this
+         * class. In CI that surfaced as an unrelated test failing with
+         * `UncaughtExceptionsBeforeTest` and a stack trace pointing at this file
+         * (konstructor#101). Anything unexpected is logged here instead, naming its
+         * actual source.
+         */
+        private val exceptionHandler = CoroutineExceptionHandler { _, thrown ->
+            if (thrown !is CancellationException) {
+                hauler.error("Uncaught failure in subprocess plumbing", thrown)
+            }
+        }
         val parentScope = CoroutineScope(
-            parentJob + Dispatchers.IO + (
+            parentJob + Dispatchers.IO + exceptionHandler + (
                 CallSign.threadLoggingName?.let(::CallSign)
                     ?: EmptyCoroutineContext
                 )
@@ -82,6 +102,12 @@ object ExecUtil {
                     proc.errorStream.copyTo(System.err)
                 } catch (t: CancellationException) {
                     // That's fine.
+                } catch (t: IOException) {
+                    // Also fine, and the normal way this pump ends: the waitFor coroutine
+                    // below closes the process streams once it exits, and a read that was
+                    // blocked at that moment wakes with "Stream closed". The process ending
+                    // is not an error, so catching only CancellationException here left an
+                    // ordinary outcome escaping as an uncaught exception (konstructor#101).
                 }
             }
             parentScope.launch {
@@ -99,6 +125,11 @@ object ExecUtil {
                     )
                 } catch (t: CancellationException) {
                     // That's fine.
+                } catch (t: IOException) {
+                    // Same shutdown race as the stderr pump above: the streams this is
+                    // built on are closed when the process exits. Leave `connection`
+                    // uncompleted — callers already handle a process that died before it
+                    // could be attached to.
                 }
             }
             parentScope.launch {

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecProcessLeakTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecProcessLeakTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.tasks
+
+import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Regression test for konstructor#101: running a subprocess to completion must leave no
+ * uncaught exception behind.
+ *
+ * [ExecUtil.ExecProcess] closes the process streams once `waitFor()` returns, which wakes
+ * the stderr pump with `IOException: Stream closed`. The pump caught only
+ * `CancellationException`, so under a bare `SupervisorJob` with no handler the exception
+ * escaped to the process-wide uncaught handler — and in a test JVM that surfaced as an
+ * unrelated test failing later with a stack trace pointing at `ExecUtil.kt`.
+ *
+ * Needs only `bash`, so unlike the rest of this package it runs without `-Dintegration`.
+ */
+class ExecProcessLeakTest {
+
+    /**
+     * Guards the guard, and it is not ceremony — it was earned.
+     *
+     * The first version of [runningASubprocessToCompletionLeavesNoUncaughtException] was
+     * built on the assumption that `kotlinx-coroutines-test` charges a leaked exception to
+     * the next `runTest`. It does so in a full CI run, but NOT when a single class is run
+     * under a `--tests` filter — and that is how the proof was being executed. Three
+     * separate reproduction attempts reported no failure, which looked like evidence the
+     * fix was unnecessary. It was not: a **deliberate** leak did not fail that `runTest`
+     * either, so the harness had never been able to see anything and all three results
+     * were void. Recording the JVM's default uncaught handler works in both cases.
+     *
+     * A regression test that has silently gone blind is worse than no test, because it
+     * reports safety. This asserts the recorder still catches a known leak, so the test
+     * below can only pass for the right reason.
+     */
+    @Test
+    fun uncaughtExceptionRecorderIsNotBlind() = runBlocking {
+        val seen = recordUncaught {
+            CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+                throw IOException("deliberate positive-control leak")
+            }
+            delay(SETTLE_MS)
+        }
+        assertTrue(
+            seen.isNotEmpty(),
+            "The uncaught-exception recorder saw nothing when handed a deliberate " +
+                "SupervisorJob leak. It is blind, so the regression test below cannot " +
+                "detect the ExecProcess leak either and its result means nothing."
+        )
+    }
+
+    @Test
+    fun runningASubprocessToCompletionLeavesNoUncaughtException() = runBlocking {
+        val seen = recordUncaught {
+            // The pump has to be BLOCKED IN A READ when the streams close — that is the
+            // only state producing "Stream closed" rather than a clean EOF. A command that
+            // writes and exits will not do it: stderr hits EOF as the process dies and
+            // `copyTo` returns normally. Backgrounding a writer that inherits stderr holds
+            // the pipe open past the direct child's exit, and making it CONTINUOUS keeps
+            // the pump looping so the close lands between two reads. That is also the
+            // production shape — see `ExecUtil.kill()`, where `bash -c "kotlin ..."` leaves
+            // a grandchild JVM holding the pipe.
+            //
+            // The writer is DRIPPED, not flooded. An unthrottled writer (`yes >&2`) also
+            // reproduces the leak, but `copyTo(System.err)` feeds Gradle's captured test
+            // output, so it exhausted the heap and failed the whole suite with an
+            // OutOfMemoryError — which this test then dutifully reported as a "leak". Many
+            // small reads spread over time give the same window with bounded memory.
+            val process = ExecUtil.executeWithChannel(
+                "(for i in \$(seq 1 400); do echo probe-\$i >&2; sleep 0.01; done) & " +
+                    "sleep 0.4; exit 0"
+            )
+            val exit = withTimeout(30_000) { process.exitCode.await() }
+            assertEquals(0, exit, "probe subprocess should exit cleanly")
+            delay(SETTLE_MS)
+        }
+        assertTrue(
+            seen.isEmpty(),
+            "Running a subprocess to completion leaked ${seen.size} uncaught " +
+                "exception(s): " + seen.joinToString { "${it::class.simpleName}: ${it.message}" }
+        )
+    }
+
+    /** Runs [block] with a recording default uncaught handler, restoring the previous one. */
+    private inline fun recordUncaught(block: () -> Unit): List<Throwable> {
+        val seen = CopyOnWriteArrayList<Throwable>()
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, thrown -> seen += thrown }
+        try {
+            block()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous)
+        }
+        return seen
+    }
+
+    private companion object {
+        /** Long enough for the pump to wake on the closed stream and for a leak to land. */
+        const val SETTLE_MS = 1_500L
+    }
+}

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecProcessLeakTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecProcessLeakTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -106,7 +107,23 @@ class ExecProcessLeakTest {
         )
     }
 
-    /** Runs [block] with a recording default uncaught handler, restoring the previous one. */
+    /**
+     * Runs [block] with a recording default uncaught handler, restoring the previous one,
+     * then DRAINS anything `kotlinx-coroutines-test` stashed on the way past.
+     *
+     * The drain is not tidiness — without it this file reproduces the very bug it guards.
+     * `ExceptionCollector.handleException` stashes an exception into `unprocessedExceptions`
+     * whenever no `runTest` is active (and still forwards it to the thread handler, which is
+     * how the recorder sees it), and that collector latches on for the rest of the fork after
+     * the first `runTest`. The next `TestScope.enter()` drains the stash and throws
+     * `UncaughtExceptionsBeforeTest` — so the deliberate leak below would fail an unrelated
+     * test later in the run, which is exactly konstructor#101's signature.
+     *
+     * It was green only by ordering luck: every `runTest` class in this module currently
+     * happens to be scanned before this one. Adding a `runTest` class that sorts after it
+     * would have turned this red on a stranger. Entering and discarding one `runTest` here
+     * consumes the stash at a known point instead.
+     */
     private inline fun recordUncaught(block: () -> Unit): List<Throwable> {
         val seen = CopyOnWriteArrayList<Throwable>()
         val previous = Thread.getDefaultUncaughtExceptionHandler()
@@ -115,6 +132,7 @@ class ExecProcessLeakTest {
             block()
         } finally {
             Thread.setDefaultUncaughtExceptionHandler(previous)
+            runCatching { runTest { } }
         }
         return seen
     }


### PR DESCRIPTION
Fixes #101

## The defect

`ExecProcess` closes the process streams once `waitFor()` returns, which wakes the stderr pump with `IOException: Stream closed`. The pump caught only `CancellationException`, so under a bare `SupervisorJob` with no handler the exception escaped to the JVM's default uncaught handler. In CI that surfaced as an **unrelated** test failing with `UncaughtExceptionsBeforeTest` and a stack trace pointing at `ExecUtil.kt`:

```
Suppressed: java.io.IOException: Stream closed
	at kotlin.io.ByteStreamsKt.copyTo(IOStreams.kt:125)
	at com.monkopedia.konstructor.tasks.ExecUtil$ExecProcess$1.invokeSuspend(ExecUtil.kt:82)
```

A catch clause narrower than the ways the operation can fail, with the punishment landing somewhere else.

## The fix — two layers, because the catch and the escape are separate defects

1. **The stderr pump and the connection setup also catch `IOException`.** A closed stream is the ordinary way a subprocess ends; catching only cancellation left a *normal outcome* escaping as an error.
2. **The scope carries a `CoroutineExceptionHandler`**, so nothing from this process's plumbing can reach the global handler again. Anything genuinely unexpected is logged where it names `ExecProcess`, instead of ambushing whichever test runs next.

Layer 1 without layer 2 would fix this instance and leave the next one to land on a stranger.

## Why it appeared now

It only fires under `-Dintegration=true`, which CI did not pass until `8c162ec` (#94, part of #82). **The leak is not new — its exposure is.** That is a gate doing its job, not a regression introduced by #94.

## Demonstrated RED

Reverting `ExecUtil.kt` to main with the test unchanged:

```
runningASubprocessToCompletionLeavesNoUncaughtException FAILED
java.lang.AssertionError: Running a subprocess to completion leaked 1 uncaught
exception(s): IOException: Stream closed
```

Restoring it goes green. `:backend:jvmTest` confirmed executed (not `UP-TO-DATE`) with result XML deleted first, and the reverted run additionally verified at the **class** level — the fix introduces a log string that exists nowhere in the original source, and it was confirmed absent from the compiled class during the red run, ruling out a stale binary.

## The test ships with its own guard, and that is not ceremony

**Three earlier versions of this test reported no failure and looked like evidence the fix was unnecessary.** They were not. A *deliberate* leak did not fail them either: the harness assumed `kotlinx-coroutines-test` charges a leaked exception to the next `runTest`, which it does in a full CI run but **not** when a single class is run under a `--tests` filter — which is how the proof was being executed. Every one of those results was void.

`uncaughtExceptionRecorderIsNotBlind` now asserts the recorder still catches a known leak, so the real test can only pass for the right reason. **A regression test that has silently gone blind is worse than no test, because it reports safety.**

Two dead ends are documented in the test body so they are not re-introduced as simplifications:
- A subprocess that writes and exits does **not** reproduce it — stderr hits EOF as the process dies, `copyTo` returns cleanly, and the later close has nothing to interrupt. The pump must be *blocked in a read*.
- An unthrottled writer (`yes >&2`) reproduces it but feeds Gradle's captured test output until the heap dies — it failed the full suite with `OutOfMemoryError`, which the test then dutifully reported as a "leak". **It passed under a `--tests` filter and would have hit CI.** The writer is now dripped: many small reads over time, same window, bounded memory.

## Verification

`./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` on the full suite — **backend 134 tests / 0 failures / 6 skipped** (28 XML), **protocol 17 / 0 / 0** (2 XML), spotless clean. Full suite deliberately, not the filtered class: the filtered run is exactly what hid the OOM.

## Notes for the reviewer

- `main` is unprotected, so `--auto` is not a CI gate — poll `gh pr checks` to completed SUCCESS yourself, then plain `--squash --delete-branch`.
- Worth challenging: the new `IOException` catches are deliberately silent, on the grounds that a closed stream at process exit is expected and logging it would be noise on every single subprocess. If you think a genuine mid-stream I/O error should be distinguishable from that, say so — it is the one judgement call in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)