### PR TITLE
fix(lsp): treat an engine that exits immediately as unavailable, and bound respawns

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcess.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcess.kt
@@ -53,6 +53,12 @@ class KotlinLspProcess private constructor(private val config: Config) {
     private var process: Process? = null
     private var connection: SingleChannelConnection<String>? = null
 
+    /** Spawn timestamps inside the current window, used to bound respawn attempts. */
+    private val recentSpawns = ArrayDeque<Long>()
+
+    /** While `now < this`, spawning is refused outright and the bridge stays inert. */
+    private var cooldownUntil = 0L
+
     /**
      * Lazily spawn (once) the warm subprocess and return a fresh subprocess-facing
      * [KsrpcLanguageServer] stub wired to [forwarder]. Returns `null` if the binary is
@@ -76,13 +82,21 @@ class KotlinLspProcess private constructor(private val config: Config) {
         }
     }
 
-    private suspend fun ensureConnection(): SingleChannelConnection<String>? {
+    /**
+     * Internal rather than private so a test can drive the spawn path directly, without
+     * needing a [KsrpcLanguageClient] forwarder for a subprocess that is never going to
+     * answer. Not part of the public surface.
+     */
+    internal suspend fun ensureConnection(): SingleChannelConnection<String>? {
         connection?.let { existing ->
             if (process?.isAlive == true) return existing
             // The warm process died; drop the stale handles and respawn below.
             shutdownLocked()
         }
         val binary = config.kotlinLspBinary ?: return null
+        val now = System.currentTimeMillis()
+        if (now < cooldownUntil) return null
+        if (!admitSpawn(now)) return null
         return try {
             val systemPath = config.kotlinLspSystemPath.absolutePath
             hauler.info("Spawning kotlin-lsp: ${binary.absolutePath} (system-path=$systemPath)")
@@ -95,6 +109,26 @@ class KotlinLspProcess private constructor(private val config: Config) {
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .start()
+            if (!isStillRunning(proc)) {
+                // An EXPIRED engine lands here (konstructor#84). It is present, executable,
+                // and `start()` returns normally — it just prints "This build of
+                // intellij-server has expired" and exits. Every other availability check
+                // passes, so without this the connection is cached as live and the bridge
+                // never degrades to inert.
+                //
+                // Deliberately "did it exit immediately" rather than "does stderr say
+                // expired": it catches a bad launcher, a missing JRE and a wrong argument
+                // the same way, and it does not depend on JetBrains' wording. A healthy
+                // engine stays up for its ~120s cold index, so it is never confused with
+                // one that dies in the first second.
+                hauler.error(
+                    "kotlin-lsp exited immediately (code ${proc.exitValue()}) — treating the " +
+                        "engine as unavailable; LSP stays off. An expired build looks exactly " +
+                        "like this."
+                )
+                runCatching { proc.destroyForcibly() }
+                return null
+            }
             val conn = (proc.inputStream to proc.outputStream).asLspConnection()
             process = proc
             connection = conn
@@ -104,6 +138,40 @@ class KotlinLspProcess private constructor(private val config: Config) {
             shutdownLocked()
             null
         }
+    }
+
+    /**
+     * True if [proc] is still alive after a short readiness window.
+     *
+     * Costs [READY_PROBE_MILLIS] once per spawn, not per request — and only on the spawn
+     * path, which already takes seconds. `waitFor` returns as soon as the process exits,
+     * so the full wait is only paid by an engine that is actually staying up.
+     */
+    private fun isStillRunning(proc: Process): Boolean =
+        !proc.waitFor(READY_PROBE_MILLIS, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+    /**
+     * Bound respawns. Without this, a dead-but-startable engine is re-spawned on every
+     * editor event — and `textDocumentHover` fires on every cursor move, so "paced by
+     * request traffic" means paced by how fast someone moves the mouse. Each attempt is a
+     * fresh ~2GB JVM; #84 records that taking prod down for six days.
+     */
+    private suspend fun admitSpawn(now: Long): Boolean {
+        while (recentSpawns.isNotEmpty() && now - recentSpawns.first() > SPAWN_WINDOW_MILLIS) {
+            recentSpawns.removeFirst()
+        }
+        if (recentSpawns.size >= MAX_SPAWNS_PER_WINDOW) {
+            cooldownUntil = now + COOLDOWN_MILLIS
+            recentSpawns.clear()
+            hauler.error(
+                "kotlin-lsp failed to stay up $MAX_SPAWNS_PER_WINDOW times in " +
+                    "${SPAWN_WINDOW_MILLIS / 1000}s — no further spawns for " +
+                    "${COOLDOWN_MILLIS / 1000}s. LSP is off until then."
+            )
+            return false
+        }
+        recentSpawns.addLast(now)
+        return true
     }
 
     /** Tear the subprocess down (best-effort, bounded). Safe to call multiple times. */
@@ -125,6 +193,15 @@ class KotlinLspProcess private constructor(private val config: Config) {
 
     companion object {
         private const val GRACE_MILLIS = 1_000L
+
+        /** How long a freshly spawned engine must stay up to count as usable. */
+        internal const val READY_PROBE_MILLIS = 1_500L
+
+        /** Spawn attempts allowed inside [SPAWN_WINDOW_MILLIS] before the cooldown. */
+        internal const val MAX_SPAWNS_PER_WINDOW = 3
+
+        internal const val SPAWN_WINDOW_MILLIS = 60_000L
+        internal const val COOLDOWN_MILLIS = 5 * 60_000L
 
         // One warm subprocess per Config (i.e. per backend). The classpath is fixed, so
         // a single instance serves all konstructions (Phase 5 hardens multiplexing).

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcessExpiredEngineTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcessExpiredEngineTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.lsp
+
+import com.monkopedia.konstructor.Config
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+
+/**
+ * Regression test for konstructor#84: an **expired** kotlin-lsp engine must be treated as
+ * unavailable, and a dead engine must not be respawned without limit.
+ *
+ * The trap this covers is that an expired EAP build passes every availability check there
+ * is — the binary exists, it is executable, and `ProcessBuilder.start()` returns normally.
+ * It simply prints "This build of intellij-server has expired" and exits. So the bridge
+ * cached the connection as live and never degraded to inert, and because
+ * `textDocumentHover` fires on every cursor move, each one respawned a fresh ~2GB JVM.
+ * #84 records that taking prod down for six days.
+ *
+ * The fake engine here reproduces exactly that shape — starts fine, exits immediately —
+ * and counts its own launches, so "how many JVMs would this have spawned" is measured
+ * rather than argued.
+ */
+class KotlinLspProcessExpiredEngineTest {
+
+    private lateinit var tempDir: File
+    private lateinit var launchLog: File
+    private lateinit var fakeEngine: File
+
+    @Before
+    fun setUp() {
+        tempDir = kotlin.io.path.createTempDirectory("lsp-expired-test-").toFile()
+        launchLog = File(tempDir, "launches.txt")
+        fakeEngine = File(tempDir, "fake-intellij-server").apply {
+            writeText(
+                """
+                #!/bin/bash
+                echo launch >> "${launchLog.absolutePath}"
+                echo "This build of intellij-server has expired" >&2
+                exit 1
+                """.trimIndent()
+            )
+            setExecutable(true)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        tempDir.deleteRecursively()
+    }
+
+    private fun launches(): Int =
+        if (launchLog.exists()) launchLog.readLines().count { it.isNotBlank() } else 0
+
+    @Test
+    fun anExpiredEngineIsTreatedAsUnavailable() = runBlocking {
+        val config = Config(tempDir, kotlinLspBinary = fakeEngine)
+        val lsp = KotlinLspProcess.forConfig(config)
+
+        val connection = lsp.ensureConnection()
+
+        assertNull(
+            connection,
+            "An engine that starts and immediately exits must be reported as unavailable " +
+                "so the bridge degrades to inert. It launched ${launches()} time(s)."
+        )
+        assertEquals(1, launches(), "the probe should have actually launched the engine once")
+    }
+
+    @Test
+    fun respawnsAreBoundedForADeadEngine() = runBlocking {
+        val config = Config(tempDir, kotlinLspBinary = fakeEngine)
+        val lsp = KotlinLspProcess.forConfig(config)
+
+        // Stand in for a user moving the cursor: every hover takes the reconnecting path.
+        repeat(ATTEMPTS) {
+            assertNull(lsp.ensureConnection(), "a dead engine must never yield a connection")
+        }
+
+        val spawned = launches()
+        assertTrue(
+            spawned <= KotlinLspProcess.MAX_SPAWNS_PER_WINDOW,
+            "A dead engine must stop being respawned. $ATTEMPTS attempts spawned $spawned " +
+                "JVMs; the cap is ${KotlinLspProcess.MAX_SPAWNS_PER_WINDOW}. Unbounded here " +
+                "is what took prod down (#84)."
+        )
+    }
+
+    private companion object {
+        /**
+         * Deliberately well above the cap: the point is to show the count STOPS, and a
+         * value at or below the cap could not tell a working bound from a broken one.
+         */
+        const val ATTEMPTS = 8
+    }
+}


### PR DESCRIPTION
Fixes #84

## The hole

An **expired** kotlin-lsp build passes every availability check there is. The binary exists, it is executable, and `ProcessBuilder.start()` returns normally — it simply prints `This build of intellij-server has expired` and exits. So `connection` was cached as live, the documented "degrade to inert" branch was never taken, and since `textDocumentHover` fires on every cursor move, each one respawned a fresh ~2GB JVM with **no ceiling**.

The issue records that taking prod down 2026-07-28 → 08-03, on a ~40-day expiry clock. This is the *expected* failure mode, not an exotic one.

## Two halves, matching the two halves of the issue

**1. Readiness.** A freshly spawned engine must still be running after a short probe window; otherwise it is reported unavailable and LSP stays off, exactly as it does for a missing binary.

Keyed on *"did it exit immediately"* rather than on JetBrains' expiry wording, deliberately: it catches a bad launcher, a missing JRE and a wrong argument the same way, and it cannot rot when their message text changes. A healthy engine stays up for its ~120s cold index, so the two are never confused — and `waitFor` returns the instant a process exits, so the full window is only ever paid by an engine that is actually working.

**2. Bounded respawn.** 3 attempts per 60s, then a 5-minute cooldown. The existing KDoc justified having no backoff because recovery is *"paced by request traffic"* — but the traffic here is the user's cursor.

`ensureConnection` becomes `internal` so the test can drive the spawn path directly, without needing a `KsrpcLanguageClient` forwarder for a subprocess that is never going to answer.

## The test measures the thing that actually hurt

A fake engine with the real failure shape — starts fine, exits instantly — that **counts its own launches**. "How many ~2GB JVMs would this have spawned" is a number, not an argument. It drives 8 attempts against a cap of 3; a count at or below the cap could not distinguish a working bound from a broken one.

## Demonstrated RED — one per half, and the first attempt was invalid

**The first control was not evidence and I am flagging it rather than quietly replacing it.** Reverting the whole file to `main` removed the API the test compiles against, so `BUILD FAILED` was a **compile error wearing a red test's clothes** — 2 seconds, 8 tasks, never reached the test task.

Each half is now disabled surgically, leaving the API intact:

```
readiness disabled, bound intact:
  anExpiredEngineIsTreatedAsUnavailable FAILED
  expected null, but was:<com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcWriterBase@3a4621bd>

bound disabled, readiness intact:
  respawnsAreBoundedForADeadEngine FAILED
  A dead engine must stop being respawned. 8 attempts spawned 8 JVMs; the cap is 3.
```

Restoring each goes green. **Two halves needed two controls:** with only the first mutation, the bound test aborted on its per-call `assertNull` and never reached the launch count, so it would have shipped on a control that never exercised it.

## Verification

`spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` — **154 tests, 0 failures, 6 skipped**, XML deleted first, tasks executed not `UP-TO-DATE`. The +3 against main's 151 is this PR's 2 tests plus the 1 `ExecuteTaskTest` case that arrived with #92.

## Why this is queued ahead of other work

The owner's instruction was **"#84 first"**, and #103 (LSP default ON) has already merged — which does not create the exposure, but does widen it from "someone who ticked a box" to anyone's first hover. This PR is the precondition recorded on #84 for the next `:8001` deploy. **Deployment remains manual and the owner's alone; nothing here deploys anything.**

## Notes for the reviewer

- Post your verdict with `gh pr review --approve | --request-changes | --comment --body-file` via the reviewer bot. **Even a "held for owner" outcome gets a review object** (`--comment` carries the prose) — a verdict posted only as an issue comment pins to no SHA and is invisible to every review-state check.
- `main` is unprotected, so `--auto` is not a CI gate — poll `gh pr checks` to completed SUCCESS yourself, then plain `--squash --delete-branch`.
- Worth challenging: `READY_PROBE_MILLIS = 1500` is a guess. It must exceed how long an expired build takes to print and exit, and stay far below a healthy engine's lifetime. If you think a slow machine could see a healthy engine die inside that window for an unrelated reason, say so.
- Also worth challenging: the cooldown makes LSP unavailable for 5 minutes after 3 bad spawns, including if the engine is replaced with a good one during it. That is deliberate — the alternative is probing a possibly-dead engine on every hover — but it is a real tradeoff, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)