### PR TITLE
fix(lsp): readiness means ANSWERED — bound the engine handshake and every engine request (#109)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/Config.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/Config.kt
@@ -19,6 +19,7 @@ import com.monkopedia.konstructor.tasks.LibsJar
 import java.io.File
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
 
 class Config(
@@ -41,6 +42,20 @@ class Config(
         System.getenv("KONSTRUCTOR_KOTLIN_LSP")
             ?: System.getProperty("konstructor.kotlinLsp")
         )?.let(::File),
+    /**
+     * Deadline for a single request made to the kotlin-lsp subprocess — the `initialize`
+     * handshake that decides whether a freshly spawned engine is usable at all, and every
+     * delegated request after it.
+     *
+     * An engine that STAYS UP but never answers is indistinguishable from a healthy one
+     * until something bounds the wait, and the editor simply hangs with LSP apparently on
+     * (#109). A healthy engine answers `initialize` in well under a second — indexing
+     * happens afterwards, and diagnostic pulls are driven by
+     * [com.monkopedia.konstructor.lsp.PullDiagnosticsPublisher] on their own budget — so
+     * this is generous by an order of magnitude and only an engine that is already broken
+     * ever reaches it.
+     */
+    val kotlinLspCallTimeout: Duration = 30.seconds,
     /**
      * Whether the script host advertises STL caching to running scripts
      * ([com.monkopedia.konstructor.lib.HostService.supportsCaching]). Turning it off

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/Config.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/Config.kt
@@ -43,19 +43,32 @@ class Config(
             ?: System.getProperty("konstructor.kotlinLsp")
         )?.let(::File),
     /**
-     * Deadline for a single request made to the kotlin-lsp subprocess — the `initialize`
-     * handshake that decides whether a freshly spawned engine is usable at all, and every
-     * delegated request after it.
+     * Deadline for a single request made to the kotlin-lsp subprocess. It covers EVERY
+     * request-shaped call: the `initialize` handshake that decides whether a freshly spawned
+     * engine is usable at all, the delegated editor requests (completion, hover,
+     * signatureHelp), and the `textDocument/diagnostic` PULL that
+     * [com.monkopedia.konstructor.lsp.PullDiagnosticsPublisher] drives. Notifications are not
+     * covered and need no cover — they complete on the write.
      *
-     * An engine that STAYS UP but never answers is indistinguishable from a healthy one
-     * until something bounds the wait, and the editor simply hangs with LSP apparently on
-     * (#109). A healthy engine answers `initialize` in well under a second — indexing
-     * happens afterwards, and diagnostic pulls are driven by
-     * [com.monkopedia.konstructor.lsp.PullDiagnosticsPublisher] on their own budget — so
-     * this is generous by an order of magnitude and only an engine that is already broken
-     * ever reaches it.
+     * An engine that STAYS UP but never answers is indistinguishable from a healthy one until
+     * something bounds the wait, and the editor simply hangs with LSP apparently on (#109).
+     * The pull seam matters most, because it is the one a user notices first and the one with
+     * no self-heal: the publisher's cold-index retry is a *cadence between completed pulls*,
+     * not a deadline, so an unbounded pull parks it for the session.
+     *
+     * A healthy engine answers `initialize` in well under a second (indexing happens
+     * afterwards) and a warm diagnostic pull in ~8s, so this is generous by design and only an
+     * engine that is already broken reaches it. A pull that does hit the deadline is an
+     * ordinary failed pull: it is logged and re-tried on the next cadence, which is strictly
+     * better than the silence it replaces.
+     *
+     * Sourced (in seconds) from `KONSTRUCTOR_KOTLIN_LSP_TIMEOUT`, or the
+     * `konstructor.kotlinLspTimeout` system property, like the other LSP knobs.
      */
-    val kotlinLspCallTimeout: Duration = 30.seconds,
+    val kotlinLspCallTimeout: Duration = (
+        System.getenv("KONSTRUCTOR_KOTLIN_LSP_TIMEOUT")
+            ?: System.getProperty("konstructor.kotlinLspTimeout")
+        )?.toLongOrNull()?.seconds ?: 30.seconds,
     /**
      * Whether the script host advertises STL caching to running scripts
      * ([com.monkopedia.konstructor.lib.HostService.supportsCaching]). Turning it off

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonNull
 
 /**
@@ -167,7 +168,7 @@ open class BridgeLanguageServer(
         /**
          * The event-driven pull→push publisher (#43). Non-null ONLY when the engine advertised
          * pull-mode ([ServerCapabilities.diagnosticProvider] != null); otherwise we run no pull
-         * machinery at all. Set by [handshakeEngine], which is where the capabilities land.
+         * machinery at all. Set by [adoptEngine], which is where the capabilities land.
          */
         var diagnostics: PullDiagnosticsPublisher? = null
     }
@@ -268,15 +269,17 @@ open class BridgeLanguageServer(
     }
 
     /**
-     * Obtain a fresh subprocess-facing stub wired to a new [Forwarder] for this session — the sole
-     * seam through which the bridge acquires an engine delegate, used by both the first
-     * [initialize] and the post-crash [reconnect] (#54). [KotlinLspProcess.connect] respawns a dead
-     * subprocess before handing back a stub, which is what makes reconnect self-healing. Returns
-     * `null` when the engine is unavailable. `open` so tests can substitute a fake engine (no real
-     * subprocess) to exercise the crash→respawn transition.
+     * Obtain a fresh [EngineSession] — a subprocess-facing stub wired to a new [Forwarder] for this
+     * session, already through the `initialize` handshake with [params] — the sole seam through
+     * which the bridge acquires an engine delegate, used by both the first [initialize] and the
+     * post-crash [reconnect] (#54). [KotlinLspProcess.connect] respawns a dead subprocess before
+     * handing back a session, which is what makes reconnect self-healing. Returns `null` when the
+     * engine is unavailable, which now includes an engine that stays up but never answers the
+     * handshake (#109). `open` so tests can substitute a fake engine (no real subprocess) to
+     * exercise the crash→respawn transition.
      */
-    protected open suspend fun connectEngine(): KsrpcLanguageServer? =
-        KotlinLspProcess.forConfig(config).connect(Forwarder())
+    protected open suspend fun connectEngine(params: InitializeParams): EngineSession? =
+        KotlinLspProcess.forConfig(config).connect(Forwarder(), params)
 
     override suspend fun initialize(params: InitializeParams): InitializeResult {
         // Stash the editor's params so a post-crash [reconnect] can replay the identical
@@ -285,53 +288,50 @@ open class BridgeLanguageServer(
         // Synthesize the per-konstruction workspace (wrapped .kt + workspace.json) and
         // spawn/connect the warm subprocess. NO blocking client-bound request here.
         lspWorkspace.synthesize()
-        val server = connectEngine()
-        if (server == null) {
+        val session = connectEngine(engineParams(params))
+        if (session == null) {
             hauler.error("kotlin-lsp engine unavailable; bridge is inert")
             return InitializeResult(capabilities = ServerCapabilities())
         }
-        val fresh = EngineConnection(server)
-        connection = fresh
-        return handshakeEngine(fresh, params)
+        connection = adoptEngine(session)
+        return session.initializeResult
     }
 
     /**
-     * Drive a freshly-[connect][KotlinLspProcess.connect]ed [connection] through the engine
-     * handshake and build its pull publisher, returning the engine's [InitializeResult]. Shared by
-     * the first [initialize] and by [reconnect] after a crash, so both replay the IDENTICAL init.
+     * The editor's [InitializeParams] rewritten for the engine. Built by both the first
+     * [initialize] and by [reconnect], so the respawned subprocess is driven through the
+     * IDENTICAL init the first one saw.
+     *
+     * Rooted at the synthesized workspace so the engine loads our workspace.json + classpath.
+     * The editor's LSPClient advertises EMPTY client capabilities; newer kotlin-lsp builds
+     * (LS-262.6274.0+) gate features on the client declaring support — with no
+     * `textDocument.completion` the engine returns no completions, and with no
+     * `textDocument.diagnostic` it omits the pull `diagnosticProvider` entirely (so
+     * [PullDiagnosticsPublisher] never runs). The bridge DOES support both (it forwards
+     * completion and runs the pull→push loop), so we advertise them on the client's behalf
+     * before forwarding.
      */
-    private suspend fun handshakeEngine(
-        connection: EngineConnection,
-        params: InitializeParams
-    ): InitializeResult {
-        // Drive the subprocess through the same handshake, but rooted at the synthesized
-        // workspace so it loads our workspace.json + classpath. The editor's LSPClient
-        // advertises EMPTY client capabilities; newer kotlin-lsp builds (LS-262.6274.0+)
-        // gate features on the client declaring support — with no `textDocument.completion`
-        // the engine returns no completions, and with no `textDocument.diagnostic` it omits
-        // the pull `diagnosticProvider` entirely (so [PullDiagnosticsPublisher] never runs).
-        // The bridge DOES support both (it forwards completion and runs the pull→push loop),
-        // so we advertise them on the client's behalf before forwarding.
-        val result = guardEngine(
-            "initialize",
-            InitializeResult(capabilities = ServerCapabilities())
-        ) {
-            connection.server.initialize(
-                params.copy(
-                    rootUri = lspWorkspace.rootUri,
-                    workspaceFolders = null,
-                    capabilities = params.capabilities.withBridgeFeatures()
-                )
-            )
+    private fun engineParams(params: InitializeParams): InitializeParams = params.copy(
+        rootUri = lspWorkspace.rootUri,
+        workspaceFolders = null,
+        capabilities = params.capabilities.withBridgeFeatures()
+    )
+
+    /**
+     * Take ownership of a freshly-[connect][KotlinLspProcess.connect]ed [session]: wrap its stub in
+     * an [EngineConnection] and build the pull publisher the engine's capabilities call for.
+     * Shared by the first [initialize] and by [reconnect] after a crash.
+     */
+    private fun adoptEngine(session: EngineSession): EngineConnection =
+        EngineConnection(session.server).apply {
+            // Detect pull-mode authoritatively (#43): a non-null diagnosticProvider in the
+            // engine's capabilities is the only signal (there is no push capability flag). Only
+            // then do we stand up the event-driven pull→push publisher; otherwise no pull
+            // machinery runs at all.
+            diagnostics = PullDiagnosticsPublisher
+                .pullProviderOf(session.initializeResult.capabilities)
+                ?.let { provider -> createPublisher(this, provider) }
         }
-        // Detect pull-mode authoritatively (#43): a non-null diagnosticProvider in the
-        // engine's capabilities is the only signal (there is no push capability flag). Only
-        // then do we stand up the event-driven pull→push publisher; otherwise no pull
-        // machinery runs at all.
-        connection.diagnostics = PullDiagnosticsPublisher.pullProviderOf(result.capabilities)
-            ?.let { provider -> createPublisher(connection, provider) }
-        return result
-    }
 
     /**
      * Build the [PullDiagnosticsPublisher] wired to THIS [connection]'s engine stub and the
@@ -472,10 +472,15 @@ open class BridgeLanguageServer(
      * silently stops compiling/executing. So every forward call degrades to inert here: the
      * worst a dead engine can do is "no completion / no hover", never kill the session.
      * Cooperative cancellation is re-thrown; everything else returns [fallback].
+     *
+     * Bounded by [Config.kotlinLspCallTimeout], because an engine that stops answering
+     * mid-session hangs the editor exactly as one that never answered `initialize` does (#109),
+     * and no probe at startup can prevent that. A deadline turns "never returns" into an
+     * ordinary engine failure, which everything above already knows how to degrade.
      */
     private suspend fun <T> guardEngine(label: String, fallback: T, block: suspend () -> T): T =
         try {
-            block()
+            withTimeout(config.kotlinLspCallTimeout) { block() }
         } catch (t: Throwable) {
             // Propagate ONLY a genuine cancellation of *this* coroutine (cooperative cancellation).
             // A FOREIGN CancellationException — the dead kotlin-lsp subprocess leg's MultiChannel
@@ -513,7 +518,8 @@ open class BridgeLanguageServer(
     ): T {
         val dead = connection ?: return fallback
         return try {
-            block(dead.server)
+            // Deadline as in [guardEngine]: a stalled engine must fail the call, not park it.
+            withTimeout(config.kotlinLspCallTimeout) { block(dead.server) }
         } catch (t: Throwable) {
             // Cooperative cancellation of THIS coroutine must propagate; a foreign cancellation
             // (the dead engine leg) must not — see [guardEngine] for the full rationale.
@@ -560,19 +566,18 @@ open class BridgeLanguageServer(
             // block the reconnect (holding [reconnectLock]) on work stuck against a dead engine.
             dead.scope.cancel()
             try {
-                // connectEngine respawns the subprocess if it died, and returns a fresh stub wired
-                // to a new Forwarder for THIS bridge's session.
-                val server = connectEngine()
+                // connectEngine respawns the subprocess if it died, replays the identical engine
+                // handshake, and returns a fresh stub wired to a new Forwarder for THIS bridge's
+                // session — or null if the respawned engine is still not usable.
+                val session = connectEngine(engineParams(params))
                     ?: return@withLock null.also {
                         hauler.error("kotlin-lsp reconnect failed to respawn; bridge stays inert")
                     }
-                val fresh = EngineConnection(server)
+                val fresh = adoptEngine(session)
                 connection = fresh
                 hauler.info("kotlin-lsp reconnected; replaying handshake + didOpen")
-                // Replay the engine handshake (this also builds the pull publisher against the
-                // fresh connection) and, if the editor had already initialized, its `initialized`.
-                handshakeEngine(fresh, params)
-                initializedParams?.let { runCatching { server.initialized(it) } }
+                // If the editor had already initialized, replay its `initialized` too.
+                initializedParams?.let { runCatching { session.server.initialized(it) } }
                 // Re-open the current document so the engine re-analyzes what the user has open.
                 replayDidOpen(fresh)
                 fresh

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServer.kt
@@ -366,7 +366,13 @@ open class BridgeLanguageServer(
                 )
             )
         },
-        awaitReady = { lifecycle.awaitInitialized() }
+        awaitReady = { lifecycle.awaitInitialized() },
+        // The SAME deadline the delegated requests get. The pull is request-shaped — the
+        // publisher's 4s cold-index cadence exists precisely because a cold pull RETURNS
+        // (empty/failed) rather than blocking — so it needs no budget of its own, and leaving it
+        // as the one unbounded engine request would reproduce #109 at the seam a user notices
+        // first, with no self-heal (reconnect only ever fires from a request-shaped call).
+        pullTimeout = config.kotlinLspCallTimeout
     )
 
     override suspend fun initialized(params: InitializedParams) {
@@ -506,6 +512,15 @@ open class BridgeLanguageServer(
      * one a captured reference would hold. At most one reconnect + one retry per failing call: no
      * backoff/retry-limit machinery — recovery is paced by request traffic (a subsequent request
      * that still fails simply tries again).
+     *
+     * ⚠️ The deadline below bounds each engine request, not the whole method, so a call that
+     * wedges, reconnects into an engine that also wedges, and retries costs up to
+     * 3 × [Config.kotlinLspCallTimeout]. That is deliberate: a single outer deadline would have to
+     * cancel a [reconnect] mid-flight, which either skips [KotlinLspProcess.connect]'s discard of
+     * the unresponsive engine (re-creating exactly the bug this fixes) or lets a
+     * CancellationException escape an LSP method — the cascade [guardEngine] exists to prevent.
+     * The worst case is self-limiting anyway: the wedged engine is discarded on the way through,
+     * and the spawn cap stops re-spawning it after [KotlinLspProcess.MAX_CONSECUTIVE_FAILURES].
      *
      * Only ever called from an editor-facing method, i.e. NEVER from inside an
      * [EngineConnection.scope] — [reconnect] cancels that scope, and a caller running in it would

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcess.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcess.kt
@@ -68,8 +68,11 @@ class KotlinLspProcess private constructor(private val config: Config) {
     private var process: Process? = null
     private var connection: SingleChannelConnection<String>? = null
 
-    /** Spawn timestamps inside the current window, used to bound respawn attempts. */
-    private val recentSpawns = ArrayDeque<Long>()
+    /**
+     * Consecutive spawns that failed to produce a *usable* engine, used to bound respawns.
+     * Reset only by an answered handshake — the same definition of usable [connect] uses.
+     */
+    private var consecutiveFailures = 0
 
     /** While `now < this`, spawning is refused outright and the bridge stays inert. */
     private var cooldownUntil = 0L
@@ -102,10 +105,10 @@ class KotlinLspProcess private constructor(private val config: Config) {
             val conn = ensureConnection() ?: return@withLock null
             try {
                 val server = conn.connectAsLspClient(forwarder)
-                EngineSession(
-                    server,
-                    withTimeout(config.kotlinLspCallTimeout) { server.initialize(params) }
-                )
+                val result = withTimeout(config.kotlinLspCallTimeout) { server.initialize(params) }
+                // An answered handshake is the only thing that clears the respawn budget.
+                consecutiveFailures = 0
+                EngineSession(server, result)
             } catch (t: TimeoutCancellationException) {
                 hauler.error(
                     "kotlin-lsp did not answer `initialize` within " +
@@ -117,6 +120,7 @@ class KotlinLspProcess private constructor(private val config: Config) {
                 // (bounded by [admitSpawn]) instead of queueing behind an engine that has
                 // already proved it will not answer.
                 shutdownLocked()
+                consecutiveFailures++
                 null
             } catch (t: Throwable) {
                 // Our own cancellation must propagate; anything else degrades LSP to off.
@@ -172,6 +176,7 @@ class KotlinLspProcess private constructor(private val config: Config) {
                         "like this."
                 )
                 runCatching { proc.destroyForcibly() }
+                consecutiveFailures++
                 return null
             }
             val conn = (proc.inputStream to proc.outputStream).asLspConnection()
@@ -181,6 +186,7 @@ class KotlinLspProcess private constructor(private val config: Config) {
         } catch (t: Throwable) {
             hauler.error("Failed to spawn kotlin-lsp subprocess", t)
             shutdownLocked()
+            consecutiveFailures++
             null
         }
     }
@@ -200,23 +206,24 @@ class KotlinLspProcess private constructor(private val config: Config) {
      * editor event — and `textDocumentHover` fires on every cursor move, so "paced by
      * request traffic" means paced by how fast someone moves the mouse. Each attempt is a
      * fresh ~2GB JVM; #84 records that taking prod down for six days.
+     *
+     * Counts CONSECUTIVE FAILURES rather than spawns-per-time-window, because a window is a
+     * bound whose reachability depends on how long each failure takes: with a handshake
+     * deadline in play a failed attempt costs the probe plus the deadline, so the earliest
+     * attempts age out of the window before the last one arrives and the cap can never trip.
+     * A failure count cannot be outrun that way, and it is the more accurate rule besides —
+     * a healthy engine that crashes and respawns cleanly should not be counted against a cap
+     * whose whole purpose is to stop hammering a BROKEN one.
      */
     private suspend fun admitSpawn(now: Long): Boolean {
-        while (recentSpawns.isNotEmpty() && now - recentSpawns.first() > SPAWN_WINDOW_MILLIS) {
-            recentSpawns.removeFirst()
-        }
-        if (recentSpawns.size >= MAX_SPAWNS_PER_WINDOW) {
-            cooldownUntil = now + COOLDOWN_MILLIS
-            recentSpawns.clear()
-            hauler.error(
-                "kotlin-lsp failed to stay up $MAX_SPAWNS_PER_WINDOW times in " +
-                    "${SPAWN_WINDOW_MILLIS / 1000}s — no further spawns for " +
-                    "${COOLDOWN_MILLIS / 1000}s. LSP is off until then."
-            )
-            return false
-        }
-        recentSpawns.addLast(now)
-        return true
+        if (consecutiveFailures < MAX_CONSECUTIVE_FAILURES) return true
+        cooldownUntil = now + COOLDOWN_MILLIS
+        consecutiveFailures = 0
+        hauler.error(
+            "kotlin-lsp failed to become usable $MAX_CONSECUTIVE_FAILURES times running — no " +
+                "further spawns for ${COOLDOWN_MILLIS / 1000}s. LSP is off until then."
+        )
+        return false
     }
 
     /** Tear the subprocess down (best-effort, bounded). Safe to call multiple times. */
@@ -242,10 +249,9 @@ class KotlinLspProcess private constructor(private val config: Config) {
         /** How long a freshly spawned engine must stay up to count as usable. */
         internal const val READY_PROBE_MILLIS = 1_500L
 
-        /** Spawn attempts allowed inside [SPAWN_WINDOW_MILLIS] before the cooldown. */
-        internal const val MAX_SPAWNS_PER_WINDOW = 3
+        /** Failed spawns in a row before the cooldown kicks in. */
+        internal const val MAX_CONSECUTIVE_FAILURES = 3
 
-        internal const val SPAWN_WINDOW_MILLIS = 60_000L
         internal const val COOLDOWN_MILLIS = 5 * 60_000L
 
         // One warm subprocess per Config (i.e. per backend). The classpath is fixed, so

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcess.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcess.kt
@@ -20,12 +20,27 @@ import com.monkopedia.hauler.hauler
 import com.monkopedia.hauler.info
 import com.monkopedia.konstructor.Config
 import com.monkopedia.ksrpc.channels.SingleChannelConnection
+import com.monkopedia.lsp.InitializeParams
+import com.monkopedia.lsp.InitializeResult
 import com.monkopedia.lsp.KsrpcLanguageClient
 import com.monkopedia.lsp.KsrpcLanguageServer
 import com.monkopedia.lsp.ksrpc.asLspConnection
 import com.monkopedia.lsp.ksrpc.connectAsLspClient
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+
+/**
+ * A kotlin-lsp engine that has ANSWERED the LSP `initialize` handshake: the
+ * subprocess-facing [server] stub and the [initializeResult] it replied with.
+ *
+ * [KotlinLspProcess.connect] hands out no other shape, so holding one of these is proof the
+ * engine is *usable* rather than merely running.
+ */
+class EngineSession(val server: KsrpcLanguageServer, val initializeResult: InitializeResult)
 
 /**
  * Manages ONE warm JetBrains `kotlin-lsp` (`intellij-server --stdio`) subprocess and
@@ -60,22 +75,52 @@ class KotlinLspProcess private constructor(private val config: Config) {
     private var cooldownUntil = 0L
 
     /**
-     * Lazily spawn (once) the warm subprocess and return a fresh subprocess-facing
-     * [KsrpcLanguageServer] stub wired to [forwarder]. Returns `null` if the binary is
-     * not available, or if spawning/connecting fails (LSP degrades to off).
+     * Lazily spawn (once) the warm subprocess, drive it through the LSP `initialize`
+     * handshake with [params], and return the resulting [EngineSession] — a stub wired to
+     * [forwarder] plus the engine's own [InitializeResult].
+     *
+     * Returns `null`, i.e. LSP degrades to off, whenever the engine is not *usable*. That
+     * is one definition, and all three shapes an unusable engine takes collapse onto it:
+     *  1. the binary is unset/missing/not executable ([Config.isKotlinLspAvailable]),
+     *  2. it starts and immediately exits — an expired build (#84), or
+     *  3. it starts, stays up, and never answers `initialize` (#109).
+     *
+     * Shape 3 is why the handshake belongs HERE and not in the caller: "still breathing a
+     * moment later" is not readiness. An expired build that hangs rather than exits passes
+     * that probe, so the connection was cached as live and the whole editor queued behind an
+     * `initialize` that never returned — silently, with the LSP toggle still reading on.
+     * Readiness therefore means *answered*, behind [Config.kotlinLspCallTimeout].
      *
      * The subprocess itself is a singleton; each call returns a stub bound to the given
      * forwarder so server→client pushes (diagnostics) for THIS session land on the right
      * editor. For Phase 2 we scope to the active konstruction, so a single warm process
      * suffices.
      */
-    suspend fun connect(forwarder: KsrpcLanguageClient): KsrpcLanguageServer? {
+    suspend fun connect(forwarder: KsrpcLanguageClient, params: InitializeParams): EngineSession? {
         if (!config.isKotlinLspAvailable) return null
         return lock.withLock {
             val conn = ensureConnection() ?: return@withLock null
             try {
-                conn.connectAsLspClient(forwarder)
+                val server = conn.connectAsLspClient(forwarder)
+                EngineSession(
+                    server,
+                    withTimeout(config.kotlinLspCallTimeout) { server.initialize(params) }
+                )
+            } catch (t: TimeoutCancellationException) {
+                hauler.error(
+                    "kotlin-lsp did not answer `initialize` within " +
+                        "${config.kotlinLspCallTimeout} — treating the engine as unavailable; " +
+                        "LSP stays off. An expired build that hangs instead of exiting looks " +
+                        "exactly like this."
+                )
+                // Discard the corpse rather than caching it: the next connect then respawns
+                // (bounded by [admitSpawn]) instead of queueing behind an engine that has
+                // already proved it will not answer.
+                shutdownLocked()
+                null
             } catch (t: Throwable) {
+                // Our own cancellation must propagate; anything else degrades LSP to off.
+                coroutineContext.ensureActive()
                 hauler.error("Failed to connect to kotlin-lsp subprocess", t)
                 null
             }

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisher.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisher.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 
 /**
  * The event-driven **pull→push diagnostics bridge** for LSP #43 (epic #35).
@@ -65,7 +66,8 @@ import kotlinx.coroutines.sync.withLock
  * (uri, identifier?); `version` through the publish seam; `awaitReady` as a generic
  * `suspend () -> Unit`; the teardown contract — the publisher relies on its injected [scope]
  * being cancelled, which the bridge does whenever the engine connection it belongs to dies, is
- * replaced or is torn down (#80), and which is the ONLY thing that bounds its pulls).
+ * replaced or is torn down (#80), and which is what bounds its retry LOOP — each individual
+ * pull is bounded by [pullTimeout]).
  *  - [pull]: how to PULL a [DocumentDiagnosticReport] for a doc (the subprocess stub's
  *    `textDocumentDiagnostic`, with `previousResultId`),
  *  - [publish]: how to PUSH a doc's diagnostics up to the target client (the bridge wires
@@ -73,7 +75,7 @@ import kotlinx.coroutines.sync.withLock
  *    `textDocumentPublishDiagnostics`),
  *  - [awaitReady]: a gate suspended on until the target client is ready to receive (the
  *    `initialized` handshake), and
- *  - timing knobs ([debounce], [coldIndexRetry]).
+ *  - timing knobs ([debounce], [coldIndexRetry], [pullTimeout]).
  *
  * It tracks per-doc [previousResultId][DocumentDiagnosticParams.previousResultId] (see
  * [resultIds]); on each pull it threads the last id, and when the server answers an
@@ -114,6 +116,15 @@ internal class PullDiagnosticsPublisher(
     private val debounce: Duration = DEFAULT_DEBOUNCE,
     /** How long to wait between re-tries of the FIRST pull, while the index is still cold. */
     private val coldIndexRetry: Duration = DEFAULT_COLD_INDEX_RETRY,
+    /**
+     * Deadline for ONE [pull]. Distinct from [coldIndexRetry], which is a *cadence between
+     * completed pulls* and therefore bounds nothing on its own: an engine that accepts a pull
+     * and never answers parks [pullOnce] — and, behind its per-doc lock, every later trigger
+     * for that doc — for the rest of the session, silently, because a pull that never returns
+     * never logs (#109). With a deadline that becomes an ordinary failed pull: logged, and
+     * re-tried on the next cadence.
+     */
+    private val pullTimeout: Duration = DEFAULT_PULL_TIMEOUT,
     /**
      * Whether [onClose] emits a clearing `publish(uri, emptyList())` so the editor drops the
      * last squiggles when a doc closes (kodemirror does not always clear on its own didClose).
@@ -231,7 +242,7 @@ internal class PullDiagnosticsPublisher(
     private suspend fun pullOnce(uri: String): PullOutcome = lockFor(uri).withLock {
         val previousResultId = resultIds[uri]
         val report = try {
-            pull(uri, previousResultId)
+            withTimeout(pullTimeout) { pull(uri, previousResultId) }
         } catch (t: Throwable) {
             // Our own cancellation must propagate, not be logged as an engine error and retried:
             // it is how [pullUntilPublished] stops when the engine connection is cancelled (#80).
@@ -267,7 +278,9 @@ internal class PullDiagnosticsPublisher(
      * analysis lands; once it publishes (or the doc closes) we stop and rely on event-driven
      * [onRefresh]/[onChange]. It needs no attempt limit of its own: the loop is bounded by the
      * [scope] it runs in, which the caller cancels when the engine connection dies or is replaced
-     * (#80) — so it can never outlive the engine it is polling.
+     * (#80) — so it can never outlive the engine it is polling. What the scope does NOT bound
+     * is a single pull: only [pullTimeout] does, and without it a wedged engine parks this loop
+     * mid-iteration, where no cadence can reach it.
      */
     private suspend fun pullUntilPublished(uri: String) {
         while (uri in openDocs) {
@@ -281,6 +294,7 @@ internal class PullDiagnosticsPublisher(
     companion object {
         private val DEFAULT_DEBOUNCE = 300.milliseconds
         private val DEFAULT_COLD_INDEX_RETRY = 4.seconds
+        private val DEFAULT_PULL_TIMEOUT = 30.seconds
 
         /**
          * The authoritative pull-mode signal: the initialize result's

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServerReconnectTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServerReconnectTest.kt
@@ -31,7 +31,6 @@ import com.monkopedia.lsp.DocumentDiagnosticReport
 import com.monkopedia.lsp.InitializeParams
 import com.monkopedia.lsp.InitializeResult
 import com.monkopedia.lsp.InitializedParams
-import com.monkopedia.lsp.KsrpcLanguageServer
 import com.monkopedia.lsp.Position
 import com.monkopedia.lsp.RelatedFullDocumentDiagnosticReport
 import com.monkopedia.lsp.ServerCapabilities
@@ -178,8 +177,16 @@ class BridgeLanguageServerReconnectTest {
         object : DefaultLanguageClient() {}
     ) {
         val handedOut = CopyOnWriteArrayList<FakeEngine>()
-        override suspend fun connectEngine(): KsrpcLanguageServer? =
-            engines()?.also { handedOut.add(it) }
+
+        /**
+         * Mirrors [KotlinLspProcess.connect]: acquiring an engine INCLUDES driving it through
+         * `initialize`, so the seam hands back a session only for an engine that answered.
+         */
+        override suspend fun connectEngine(params: InitializeParams): EngineSession? {
+            val engine = engines() ?: return null
+            handedOut.add(engine)
+            return EngineSession(engine, engine.initialize(params))
+        }
     }
 
     private fun seedContent(text: String) {

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServerReconnectTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/BridgeLanguageServerReconnectTest.kt
@@ -185,7 +185,11 @@ class BridgeLanguageServerReconnectTest {
         override suspend fun connectEngine(params: InitializeParams): EngineSession? {
             val engine = engines() ?: return null
             handedOut.add(engine)
-            return EngineSession(engine, engine.initialize(params))
+            // ...including the swallow: a handshake that throws (or never answers) means the
+            // engine is unusable, and the real connect() reports that as null rather than
+            // letting it escape. The bridge's initialize/reconnect now call this OUTSIDE any
+            // guard, so a propagating fake would test a contract production does not have.
+            return runCatching { EngineSession(engine, engine.initialize(params)) }.getOrNull()
         }
     }
 

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcessExpiredEngineTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcessExpiredEngineTest.kt
@@ -16,35 +16,48 @@
 package com.monkopedia.konstructor.lsp
 
 import com.monkopedia.konstructor.Config
+import com.monkopedia.lsp.ClientCapabilities
+import com.monkopedia.lsp.DefaultLanguageClient
+import com.monkopedia.lsp.InitializeParams
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Before
 
 /**
- * Regression test for konstructor#84: an **expired** kotlin-lsp engine must be treated as
- * unavailable, and a dead engine must not be respawned without limit.
+ * Regression test for the two shapes an **expired** kotlin-lsp engine takes: it may exit
+ * immediately (konstructor#84) or stay up and never answer `initialize` (konstructor#109).
+ * Either way it must be treated as unavailable so the bridge degrades to inert, and a dead
+ * engine must not be respawned without limit.
  *
- * The trap this covers is that an expired EAP build passes every availability check there
- * is — the binary exists, it is executable, and `ProcessBuilder.start()` returns normally.
- * It simply prints "This build of intellij-server has expired" and exits. So the bridge
- * cached the connection as live and never degraded to inert, and because
- * `textDocumentHover` fires on every cursor move, each one respawned a fresh ~2GB JVM.
- * #84 records that taking prod down for six days.
+ * The trap in both is that an expired EAP build passes every availability check there is —
+ * the binary exists, it is executable, and `ProcessBuilder.start()` returns normally.
  *
- * The fake engine here reproduces exactly that shape — starts fine, exits immediately —
- * and counts its own launches, so "how many JVMs would this have spawned" is measured
- * rather than argued.
+ *  - **#84** prints "This build of intellij-server has expired" and exits. The bridge cached
+ *    the connection as live and never degraded to inert, and because `textDocumentHover`
+ *    fires on every cursor move, each one respawned a fresh ~2GB JVM. #84 records that taking
+ *    prod down for six days.
+ *  - **#109** is the quiet one: the process stays up, so "is it still alive?" says yes, and
+ *    everything downstream parks forever on an `initialize` that never comes back. Nothing is
+ *    logged as failed and the LSP toggle still reads on — the editor just never produces
+ *    diagnostics or completions.
+ *
+ * The fake engines here reproduce both shapes and count their own launches, so "how many JVMs
+ * would this have spawned" is measured rather than argued.
  */
 class KotlinLspProcessExpiredEngineTest {
 
     private lateinit var tempDir: File
     private lateinit var launchLog: File
     private lateinit var fakeEngine: File
+    private lateinit var hangingEngine: File
 
     @Before
     fun setUp() {
@@ -57,6 +70,18 @@ class KotlinLspProcessExpiredEngineTest {
                 echo launch >> "${launchLog.absolutePath}"
                 echo "This build of intellij-server has expired" >&2
                 exit 1
+                """.trimIndent()
+            )
+            setExecutable(true)
+        }
+        // #109's shape: up, holding its pipes open, answering nothing. Sleeping well beyond any
+        // budget in this test is the whole point — the engine is never the thing that gives up.
+        hangingEngine = File(tempDir, "hanging-intellij-server").apply {
+            writeText(
+                """
+                #!/bin/bash
+                echo launch >> "${launchLog.absolutePath}"
+                sleep 600
                 """.trimIndent()
             )
             setExecutable(true)
@@ -105,11 +130,61 @@ class KotlinLspProcessExpiredEngineTest {
         )
     }
 
+    @Test
+    fun anEngineThatNeverAnswersInitializeIsTreatedAsUnavailable() = runBlocking {
+        val config = Config(
+            tempDir,
+            kotlinLspBinary = hangingEngine,
+            kotlinLspCallTimeout = ENGINE_DEADLINE
+        )
+        val lsp = KotlinLspProcess.forConfig(config)
+
+        // Bound the WHOLE call rather than asserting a flag: the defect IS the hang, so a test
+        // that merely waits on it would fail by timing out the entire suite instead of naming
+        // this. Null here means connect() never came back inside a budget many times the
+        // engine's own deadline — i.e. the editor would still be sitting there.
+        val reportedUnavailable = withTimeoutOrNull(HANG_BUDGET) {
+            lsp.connect(object : DefaultLanguageClient() {}, INIT_PARAMS) == null
+        }
+
+        assertNotNull(
+            reportedUnavailable,
+            "connect() did not return within $HANG_BUDGET against an engine that answers " +
+                "nothing. Readiness has to mean ANSWERED, not still-breathing: a process that " +
+                "stays up passes the liveness probe, and the editor then hangs behind an " +
+                "`initialize` that never comes back (#109)."
+        )
+        assertTrue(
+            reportedUnavailable,
+            "an engine that never answers `initialize` must be reported unavailable so the " +
+                "bridge degrades to inert"
+        )
+        assertEquals(1, launches(), "the probe should have actually launched the engine once")
+
+        // The hung engine must be DISCARDED, not cached: the next attempt spawns a fresh process
+        // (bounded by MAX_SPAWNS_PER_WINDOW) instead of queueing behind a corpse that has already
+        // proved it will not answer.
+        assertNotNull(lsp.ensureConnection(), "a live-but-mute process still passes liveness")
+        assertEquals(2, launches(), "the unresponsive engine must be discarded, not reused")
+        lsp.shutdown()
+    }
+
     private companion object {
         /**
          * Deliberately well above the cap: the point is to show the count STOPS, and a
          * value at or below the cap could not tell a working bound from a broken one.
          */
         const val ATTEMPTS = 8
+
+        /** What the fake engine gets to answer `initialize` in. Short: it never answers. */
+        val ENGINE_DEADLINE = 1.seconds
+
+        /** Generous against [ENGINE_DEADLINE], tight against "forever" — see the assertion. */
+        val HANG_BUDGET = 30.seconds
+
+        val INIT_PARAMS = InitializeParams(
+            capabilities = ClientCapabilities(),
+            rootUri = "file:///workspace"
+        )
     }
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcessExpiredEngineTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/KotlinLspProcessExpiredEngineTest.kt
@@ -121,12 +121,14 @@ class KotlinLspProcessExpiredEngineTest {
             assertNull(lsp.ensureConnection(), "a dead engine must never yield a connection")
         }
 
-        val spawned = launches()
-        assertTrue(
-            spawned <= KotlinLspProcess.MAX_SPAWNS_PER_WINDOW,
-            "A dead engine must stop being respawned. $ATTEMPTS attempts spawned $spawned " +
-                "JVMs; the cap is ${KotlinLspProcess.MAX_SPAWNS_PER_WINDOW}. Unbounded here " +
-                "is what took prod down (#84)."
+        // Equality, not <=: "at most the cap" is satisfied by a cap that never trips, which is
+        // how a bound ends up measuring nothing. $ATTEMPTS attempts must produce exactly the cap.
+        assertEquals(
+            KotlinLspProcess.MAX_CONSECUTIVE_FAILURES,
+            launches(),
+            "A dead engine must stop being respawned: $ATTEMPTS attempts must spawn exactly " +
+                "${KotlinLspProcess.MAX_CONSECUTIVE_FAILURES} JVMs and then stop. Unbounded " +
+                "here is what took prod down (#84)."
         )
     }
 
@@ -144,7 +146,7 @@ class KotlinLspProcessExpiredEngineTest {
         // this. Null here means connect() never came back inside a budget many times the
         // engine's own deadline — i.e. the editor would still be sitting there.
         val reportedUnavailable = withTimeoutOrNull(HANG_BUDGET) {
-            lsp.connect(object : DefaultLanguageClient() {}, INIT_PARAMS) == null
+            lsp.connect(client(), INIT_PARAMS) == null
         }
 
         assertNotNull(
@@ -169,6 +171,37 @@ class KotlinLspProcessExpiredEngineTest {
         lsp.shutdown()
     }
 
+    @Test
+    fun theRespawnCapTripsForAnEngineThatNeverAnswers() = runBlocking {
+        val config = Config(
+            tempDir,
+            kotlinLspBinary = hangingEngine,
+            kotlinLspCallTimeout = ENGINE_DEADLINE
+        )
+        val lsp = KotlinLspProcess.forConfig(config)
+
+        // Every attempt costs the liveness probe PLUS the handshake deadline, which is exactly
+        // what a spawns-per-time-window bound cannot survive: the early attempts age out of the
+        // window before the last one arrives, so the cap never trips and the JVM storm #84
+        // records is back. Counting consecutive failures is independent of how slow a failure
+        // is, which is what makes this assertion mean something at any deadline.
+        repeat(ATTEMPTS) {
+            assertTrue(
+                withTimeoutOrNull(HANG_BUDGET) { lsp.connect(client(), INIT_PARAMS) == null }
+                    == true,
+                "every attempt must RETURN and report the engine unavailable"
+            )
+        }
+
+        assertEquals(
+            KotlinLspProcess.MAX_CONSECUTIVE_FAILURES,
+            launches(),
+            "$ATTEMPTS attempts against an unresponsive engine must spawn exactly " +
+                "${KotlinLspProcess.MAX_CONSECUTIVE_FAILURES} JVMs and then stop"
+        )
+        lsp.shutdown()
+    }
+
     private companion object {
         /**
          * Deliberately well above the cap: the point is to show the count STOPS, and a
@@ -186,5 +219,8 @@ class KotlinLspProcessExpiredEngineTest {
             capabilities = ClientCapabilities(),
             rootUri = "file:///workspace"
         )
+
+        /** A do-nothing forwarder: the fake engines never push anything at it. */
+        fun client(): DefaultLanguageClient = object : DefaultLanguageClient() {}
     }
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisherTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/lsp/PullDiagnosticsPublisherTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
@@ -55,6 +56,9 @@ import kotlinx.coroutines.test.runTest
 class PullDiagnosticsPublisherTest {
 
     private val uri = "file:///0/0/content.csgs"
+
+    /** The pull deadline under test. Short so the virtual clock reaches it obviously. */
+    private val pullDeadline = 30.seconds
 
     private fun fullReport(resultId: String?, vararg messages: String): DocumentDiagnosticReport =
         RelatedFullDocumentDiagnosticReport(
@@ -275,8 +279,10 @@ class PullDiagnosticsPublisherTest {
         val publisher = newPublisher(rec)
 
         // Start a change-triggered pull and let it reach the (gated) pull seam, then hold it.
+        // Stepped rather than advanceUntilIdle(): a pull now has a deadline, and running the
+        // clock to idle would fire it and leave this test asserting nothing.
         publisher.onChange(uri)
-        testScheduler.advanceUntilIdle()
+        testScheduler.advanceTimeBy(1.seconds)
         assertEquals(1, rec.pullCalls.size, "the change pull reached the pull seam")
         // Nothing published yet (pull is suspended on the gate); also no clearing publish yet.
         val publishesWhileInFlight = rec.publishes.size
@@ -284,13 +290,13 @@ class PullDiagnosticsPublisherTest {
         // The doc closes while the pull is still in flight. This drops it from openDocs and
         // emits the clear-on-close publish.
         publisher.onClose(uri)
-        testScheduler.advanceUntilIdle()
+        testScheduler.advanceTimeBy(1.seconds)
         val afterClose = rec.publishes.size
 
         // Now let the in-flight pull complete: its (now-stale) full report must NOT publish,
         // because the doc is no longer open.
         gate.complete(Unit)
-        testScheduler.advanceUntilIdle()
+        testScheduler.advanceTimeBy(1.seconds)
 
         assertEquals(
             afterClose,
@@ -360,14 +366,46 @@ class PullDiagnosticsPublisherTest {
         )
     }
 
+    // --- a pull is bounded, not merely re-tried (#109) --------------------------------
+
+    @Test
+    fun `a pull the engine never answers is bounded and re-tried, not parked`() = runTest {
+        val rec = Recorder()
+        // The engine takes the pull and never answers — #109's shape at the seam a user
+        // notices first, and the one with no self-heal: reconnect only ever fires from a
+        // request-shaped call, and a user who is only typing makes none.
+        rec.pullGate = CompletableDeferred()
+        rec.reports = { fullReport(resultId = "rid", "boom") }
+        // Same shape as the cancellation guard below: the retry loop is unbounded by design, so
+        // it runs in the engine connection's scope and the test ends it the way the bridge does.
+        val connectionScope = CoroutineScope(coroutineContext + Job())
+        val publisher = connectionScope.newPublisher(rec)
+
+        publisher.onOpen(uri)
+        // Long enough for several deadline+cadence cycles. [coldIndexRetry] cannot rescue
+        // this on its own: it is the gap BETWEEN completed pulls, so an unbounded pull never
+        // reaches it and pullCalls stays stuck at 1 for the life of the session.
+        testScheduler.advanceTimeBy((pullDeadline + 10.seconds) * 3)
+        val attempts = rec.pullCalls.size
+        connectionScope.cancel()
+
+        assertTrue(
+            attempts > 1,
+            "a pull that never answers must hit its deadline and be re-tried; the loop only " +
+                "made $attempts attempt(s), i.e. it is parked on the first one"
+        )
+    }
+
     private fun CoroutineScope.newPublisher(
         rec: Recorder,
+        pullTimeout: Duration = pullDeadline,
         provider: com.monkopedia.lsp.ServerCapabilitiesDiagnosticProvider = DiagnosticOptions(
             interFileDependencies = false,
             workspaceDiagnostics = false
         )
     ): PullDiagnosticsPublisher = PullDiagnosticsPublisher(
         scope = this,
+        pullTimeout = pullTimeout,
         diagnosticProvider = provider,
         pull = { _, previousResultId ->
             rec.pullCalls.add(previousResultId)


### PR DESCRIPTION
Fixes #109

## The shape

An unusable kotlin-lsp engine takes three shapes. Two were covered:

| # | shape | covered by |
| --- | --- | --- |
| 1 | binary missing / not executable / env unset | `isKotlinLspAvailable` |
| 2 | starts, prints its expiry notice, **exits** | #108 |
| 3 | starts, **stays up**, never answers `initialize` | **this PR** |

#108's readiness probe asks one question — *is the process still alive after ~1500ms?* — and shape 3 answers **yes**. So `connection` was cached as live, the bridge took the fully-connected path, and everything downstream parked on an engine that would never reply. `callTimeout` wraps only the `lsp()` sub-service factory, not the delegate calls made through it, so the bridge's `initialize` toward the engine had no deadline and the frontend's `client.initialize()` hung behind it.

Worse than the outage next to it because it is **silent**: nothing is logged as failed, no error surfaces, the settings toggle still reads on, and the editor simply never produces diagnostics or completions. Since LSP went default-ON the exposed population is everyone.

## The change

**Readiness means *answered*, not *still breathing*** — and rather than adding a third special case, all three shapes collapse onto one definition of usable.

- `KotlinLspProcess.connect` owns the LSP `initialize` handshake and runs it behind `Config.kotlinLspCallTimeout`. A timeout is treated exactly as #108 treats an immediate exit: log it, destroy the process so it is not cached, return `null`, and let the bounded-respawn logic absorb the retries.
- It therefore returns an `EngineSession` (the stub plus the engine's own `InitializeResult`) instead of a bare stub — holding one is proof the engine *answered*, not merely that it is running. The bridge's "engine unavailable ⇒ inert server" path already existed and is unchanged; `handshakeEngine` splits into `engineParams` (the rewrite the engine needs) and `adoptEngine` (wrap + stand up the pull publisher), both shared by first-initialize and post-crash reconnect exactly as before.
- **Every request-shaped engine call carries the same deadline**, because an engine that stops answering *after* a successful handshake produces the identical hang and no startup probe can prevent it: `guardEngine` / `withLiveDelegate` cover initialize, completion, completionItemResolve, hover and signatureHelp, and `PullDiagnosticsPublisher` covers `textDocument/diagnostic`. Notifications are not covered and need no cover — they complete on the write.
- `Config.kotlinLspCallTimeout` defaults to 30s, sourced from `KONSTRUCTOR_KOTLIN_LSP_TIMEOUT` / `konstructor.kotlinLspTimeout` like the other LSP knobs. A healthy engine answers `initialize` in well under a second (indexing happens afterwards) and a warm pull in ~8s, so only an already-broken engine reaches it.

### Review round 2

**The pull seam was the one unbounded engine request** — and the seam that matters most. `PullDiagnosticsPublisher`'s 4s cold-index retry is a *cadence between completed pulls*, not a deadline: it advances only if a pull returns, so a wedged engine parks `pullOnce` — and, behind its per-doc lock, every later trigger for that doc — for the session. That is this issue's exact symptom at the seam a user notices FIRST, and the one with **no self-heal**, since reconnect only ever fires from a request-shaped call and a user who is only typing makes none. The publisher gains a `pullTimeout` knob beside its existing timing knobs and the bridge passes the same deadline; a pull that hits it is an ordinary failed pull (logged, re-tried on the next cadence), which is strictly better than the silence it replaces. The `Config` KDoc that claimed pulls ran "on their own budget" is corrected rather than left asserting a bound the code lacked.

**The respawn cap could never trip.** A failed attempt costs the 1.5s probe plus the 30s deadline, so under a 3-spawns-per-60s window the first spawn aged out before the third arrived — `recentSpawns` peaked at 2 and the cooldown was unreachable. Replaced with a **consecutive-failure count**, reset only by an answered handshake: time-independent, so no deadline can outrun it, and more accurate anyway (a healthy engine that crashes and respawns cleanly should not count against a cap meant to stop hammering a broken one). It also deletes the deque and the window constant. Both bound tests now assert **equality** with the cap rather than `<=` — "at most the cap" is satisfied by a cap that never trips, which is exactly how a bound ends up measuring nothing.

Also from review: the reconnect test's fake seam now swallows a throwing `initialize` to null as the real `connect` does (that call moved outside any guard, so a propagating fake would pin a contract production does not have).

**Deliberately not changed — worst-case editor latency.** The deadline bounds each engine request, not the whole `withLiveDelegate`, so a call that wedges → reconnects into an engine that also wedges → retries costs up to 3 × the deadline. A single outer bound would have to cancel a `reconnect` mid-flight, which either skips `connect`'s discard of the unresponsive engine (re-creating this very bug) or lets a CancellationException escape an LSP method — the cascade `guardEngine` exists to prevent (#54 / ksrpc#228). The worst case is self-limiting: the wedged engine is discarded on the way through and the cap stops re-spawning it. This is now stated in the `withLiveDelegate` KDoc rather than left for the next reader to discover.

## Tests

The fake-engine harness in `KotlinLspProcessExpiredEngineTest` gains a script that **sleeps instead of exiting** — a real subprocess, real stdio, real ksrpc, answering nothing. The readiness assertion bounds the **whole call** with `withTimeoutOrNull` rather than checking a flag: the defect *is* a hang, so a test that merely waited would fail by timing out the entire suite instead of reporting this. It then proves the hung process is discarded rather than cached, and a second test proves the respawn cap trips for the hanging shape too.

**Demonstrated REDs**, each by disabling only the mechanism under test with its API intact (so every run reached `:backend:jvmTest` rather than failing to compile):

| disabled | failure |
| --- | --- |
| handshake deadline | `connect() did not return within 30s against an engine that answers nothing. Readiness has to mean ANSWERED, not still-breathing…` |
| pull deadline | `a pull that never answers must hit its deadline and be re-tried; the loop only made 1 attempt(s), i.e. it is parked on the first one` |
| respawn cap | `8 attempts must spawn exactly 3 JVMs and then stop expected:<3> but was:<8>` — both engine shapes |

Green, twice, from freshly deleted-and-regenerated XML with the compile tasks executed (not `UP-TO-DATE`): `./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` → **backend 140 tests / 6 skipped / 0 failures, protocol 17 tests / 0 failures** on both runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
