### PR TITLE
fix(render): keep a failed target dirty so re-running retries it (#104)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
@@ -44,6 +44,15 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 
+/**
+ * What a render touched.
+ *
+ * [attemptedTargets] is the subset of [allTargets] the render actually tried to build — the
+ * script's exports plus any requested extras that exist. Which of those succeeded is reported
+ * separately, in the render's [TaskResult.taskArguments].
+ */
+data class RenderedTargets(val allTargets: List<String>, val attemptedTargets: List<String>)
+
 interface KonstructionController {
     val callSign: CallSign
     val paths: PathController.Paths
@@ -55,7 +64,7 @@ interface KonstructionController {
     suspend fun write(content: ByteReadChannel)
     suspend fun compile()
     suspend fun lastCompileResult(): TaskResult
-    suspend fun render(targets: List<String>): List<String>
+    suspend fun render(targets: List<String>): RenderedTargets
     suspend fun lastRenderResult(): TaskResult
     suspend fun renderFile(target: String): File?
 }
@@ -114,7 +123,7 @@ class KonstructionControllerImpl(
         }
     }
 
-    override suspend fun render(targets: List<String>): List<String> {
+    override suspend fun render(targets: List<String>): RenderedTargets {
         contentFileLock.withLock {
             for (target in targets) {
                 val targetFile = File(paths.renderOutput, "$target.stl")
@@ -131,11 +140,11 @@ class KonstructionControllerImpl(
                 extraTargets = targets,
                 subprocessExit = scriptExit
             )
-            val (result, executedTargets) = executeTask.execute()
+            val (result, renderedTargets) = executeTask.execute()
             paths.renderResultFile.outputStream().use { output ->
                 config.json.encodeToStream(result, output)
             }
-            return executedTargets
+            return renderedTargets
         }
     }
 

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -272,6 +272,10 @@ class KonstructionServiceImpl(
                         if (target in latestBuilt) {
                             CLEAN
                         } else {
+                            // Not built — either never attempted, or attempted and failed.
+                            // Either way it keeps whatever dirty state it had, so a target
+                            // that failed at execute time stays NEEDS_EXEC and the guard
+                            // above lets a later request re-enter render() (#104).
                             existingTargets[target]?.state ?: NEEDS_EXEC
                         }
                     existingTargets[target]?.let {

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -263,21 +263,24 @@ class KonstructionServiceImpl(
             if (info.dirtyState == NEEDS_EXEC ||
                 info.targets.any { it.name in targets && it.state == NEEDS_EXEC }
             ) {
-                val allTargets = konstructionController.render(targets)
+                val rendered = konstructionController.render(targets)
                 val latestBuilt = konstructionController.lastRenderResult().taskArguments
                 val existingTargets = info.targets.associateBy { it.name }
                 val changedTargets = mutableListOf<KonstructionTarget>()
-                val targets = allTargets.map { target ->
-                    val dirtyState =
-                        if (target in latestBuilt) {
-                            CLEAN
-                        } else {
-                            // Not built — either never attempted, or attempted and failed.
-                            // Either way it keeps whatever dirty state it had, so a target
-                            // that failed at execute time stays NEEDS_EXEC and the guard
-                            // above lets a later request re-enter render() (#104).
-                            existingTargets[target]?.state ?: NEEDS_EXEC
-                        }
+                val targets = rendered.allTargets.map { target ->
+                    val dirtyState = when {
+                        target in latestBuilt -> CLEAN
+
+                        // Attempted but not built: leave it dirty so the guard above lets a
+                        // later request re-enter render(). Keeping its previous state would
+                        // record a target that had already built as CLEAN even though its
+                        // render just failed, and the retry would be skipped in favour of
+                        // re-broadcasting the stale failure (#104).
+                        target in rendered.attemptedTargets -> NEEDS_EXEC
+
+                        // Untouched by this render, so its state is still whatever it was.
+                        else -> existingTargets[target]?.state ?: NEEDS_EXEC
+                    }
                     existingTargets[target]?.let {
                         if (it.state != dirtyState) {
                             it.copy(state = dirtyState).also(changedTargets::add)
@@ -293,12 +296,16 @@ class KonstructionServiceImpl(
                 konstructionController.info = newInfo
                 broadcast {
                     onInfoChanged(newInfo, changedTargets)
-                    for (rendered in latestBuilt) {
+                    // Every attempted target, not only the built ones: render() deleted the
+                    // STL of each target it was asked for, so one that then failed to build
+                    // must broadcast a null render (konstructed() finds no file) to clear the
+                    // geometry the editor is still showing for it.
+                    for (attempted in rendered.attemptedTargets) {
                         onRenderChanged(
                             KonstructionRender(
                                 info.konstruction,
-                                rendered,
-                                konstructed(rendered)
+                                attempted,
+                                konstructed(attempted)
                             )
                         )
                     }

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecuteTask.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecuteTask.kt
@@ -20,6 +20,7 @@ import com.monkopedia.hauler.error
 import com.monkopedia.hauler.hauler
 import com.monkopedia.hauler.info
 import com.monkopedia.konstructor.Config
+import com.monkopedia.konstructor.RenderedTargets
 import com.monkopedia.konstructor.common.MessageImportance
 import com.monkopedia.konstructor.common.TaskMessage
 import com.monkopedia.konstructor.common.TaskResult
@@ -58,7 +59,7 @@ class ExecuteTask(
     private val subprocessExit: Deferred<Int>? = null
 ) {
     private val hauler by lazy { hauler() }
-    suspend fun execute(): Pair<TaskResult, List<String>> {
+    suspend fun execute(): Pair<TaskResult, RenderedTargets> {
         val messages = mutableListOf<TaskMessage>()
         var isSuccessful = true
         val exports = script.listTargets(onlyExports = true)
@@ -116,7 +117,7 @@ class ExecuteTask(
             builtTargets,
             if (isSuccessful) SUCCESS else FAILURE,
             messages
-        ) to allTargets
+        ) to RenderedTargets(allTargets, attemptedTargets)
     }
 
     /**

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecuteTask.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecuteTask.kt
@@ -64,8 +64,9 @@ class ExecuteTask(
         val exports = script.listTargets(onlyExports = true)
         val allTargets = script.listTargets(onlyExports = false).map { it.name }
         val validExtraTargets = extraTargets.filter { it in allTargets }
-        val builtTargets = (exports.map { it.name } + validExtraTargets).distinct()
-        for (export in builtTargets) {
+        val attemptedTargets = (exports.map { it.name } + validExtraTargets).distinct()
+        val builtTargets = mutableListOf<String>()
+        for (export in attemptedTargets) {
             hauler.debug("Starting building $export")
             val exportService = script.buildTarget(export)
             val status = awaitTerminalStatus(export, exportService)
@@ -73,10 +74,14 @@ class ExecuteTask(
             val targetBuilt = status == BUILT
             // Accumulate — one failed target must fail the whole render. This previously
             // ASSIGNED (`isSuccessful = status == BUILT`), i.e. last-target-wins: with a live
-            // subprocess, target A failing then target B succeeding reported SUCCESS and the
-            // caller marked the failed target CLEAN, so it never retried (#81).
+            // subprocess, target A failing then target B succeeding reported SUCCESS (#81).
             isSuccessful = isSuccessful && targetBuilt
-            if (!targetBuilt) {
+            if (targetBuilt) {
+                // Only targets that actually built are reported. The caller derives dirty
+                // state from this list, so a failed target must be left out of it to stay
+                // NEEDS_EXEC and be retried by a later render (#104).
+                builtTargets += export
+            } else {
                 val trace = runCatching { exportService.getErrorTrace() }.getOrNull()
                 hauler.error("Error: $trace")
                 // Surface the execute-phase error to the UI. The trace is a runtime error,

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/FailedRenderRetryTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/FailedRenderRetryTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.monkopedia.konstructor.integration
+
+import com.monkopedia.konstructor.KonstructionServiceImpl
+import com.monkopedia.konstructor.common.DirtyState.CLEAN
+import com.monkopedia.konstructor.common.DirtyState.NEEDS_EXEC
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionInfo
+import com.monkopedia.konstructor.common.TaskStatus.FAILURE
+import com.monkopedia.konstructor.common.TaskStatus.SUCCESS
+import com.monkopedia.konstructor.logging.WarehouseWrapper
+import com.monkopedia.konstructor.testutil.TestEnvironment
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.encodeToStream
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Coverage for #104: a target that fails at execute time must stay dirty so a later request
+ * retries it.
+ *
+ * #81 made a partial render report FAILURE, but the failed target was still recorded CLEAN
+ * (dirty state came from the *attempted* target list, not from what actually built). With the
+ * target CLEAN the guard in `KonstructionServiceImpl.konstruct()` skipped `render()` entirely
+ * on the next request and just re-broadcast the stale failure — so re-running did nothing and
+ * only an edit-and-recompile could clear it.
+ *
+ * These drive the real pipeline (kotlinc + the script subprocess) through
+ * [KonstructionServiceImpl], because the defect only shows up in the interaction between what
+ * `ExecuteTask` reports and how the service turns it into dirty state.
+ */
+class FailedRenderRetryTest {
+
+    private lateinit var env: TestEnvironment
+    private lateinit var service: KonstructionServiceImpl
+
+    @Before
+    fun setUp() {
+        // Needs the full build (lib shadowJar bundled into backend resources), same as the
+        // other compile+execute integration tests.
+        assumeTrue(
+            "Set -Dintegration=true to run compile integration tests",
+            System.getProperty("integration") == "true"
+        )
+        env = TestEnvironment()
+        env.createWorkspaceDir("ws1", "Test")
+        val dir = File(env.tempDir, "ws1/k1")
+        dir.mkdirs()
+        val info = KonstructionInfo(
+            Konstruction(name = "test", workspaceId = "ws1", id = "k1"),
+            CLEAN
+        )
+        File(dir, "info.json").outputStream().use {
+            env.config.json.encodeToStream(info, it)
+        }
+        service = KonstructionServiceImpl(
+            config = env.config,
+            workspaceId = "ws1",
+            id = "k1",
+            warehouseWrapper = WarehouseWrapper(),
+            onClose = {}
+        )
+    }
+
+    @After
+    fun tearDown() {
+        if (::env.isInitialized) {
+            env.close()
+        }
+    }
+
+    /**
+     * Both directions of the dirty state a render leaves behind: the target that built is
+     * CLEAN, the target that failed is still NEEDS_EXEC.
+     */
+    @Test
+    fun failedTargetStaysDirtyWhileBuiltTargetGoesClean() = runBlocking {
+        service.set(
+            """
+            val bad by primitive {
+               throw RuntimeException("boom-104")
+            }
+            val good by primitive {
+               cube {
+                   dimensions = xyz(1.0, 1.0, 1.0)
+               }
+            }
+            export("bad")
+            export("good")
+            """.trimIndent()
+        )
+        assertEquals(SUCCESS, service.compile(Unit).status, "The script must compile")
+
+        val result = service.konstruct("bad")
+        assertEquals(FAILURE, result.status, "Render result: $result")
+
+        val targets = service.getInfo(Unit).targets.associate { it.name to it.state }
+        assertEquals(
+            CLEAN,
+            targets["good"],
+            "A target that built must be marked clean. Targets: $targets"
+        )
+        assertEquals(
+            NEEDS_EXEC,
+            targets["bad"],
+            "A target that failed at execute time must stay dirty so it can be retried. " +
+                "Targets: $targets"
+        )
+    }
+
+    /**
+     * The end-to-end half: a re-request on a failed target must actually re-enter `render()`.
+     *
+     * The script fails until a marker file appears, and nothing else about the konstruction
+     * changes between the two requests — no edit, no recompile. So the second request can only
+     * report SUCCESS if it really ran the render again; if the guard skips it, the stale
+     * FAILURE comes back instead. That silent skip is the failure mode, which is why this
+     * asserts the retry rather than just the dirty flag.
+     */
+    @Test
+    fun reRequestOfAFailedTargetRunsTheRenderAgain() = runBlocking {
+        val marker = File(env.tempDir, "let-it-build")
+        service.set(
+            """
+            val flaky by primitive {
+               if (!java.io.File("${marker.absolutePath}").exists()) {
+                   throw RuntimeException("boom-104")
+               }
+               cube {
+                   dimensions = xyz(1.0, 1.0, 1.0)
+               }
+            }
+            export("flaky")
+            """.trimIndent()
+        )
+        assertEquals(SUCCESS, service.compile(Unit).status, "The script must compile")
+
+        val first = service.konstruct("flaky")
+        assertEquals(FAILURE, first.status, "First render must fail. Result: $first")
+        assertNull(service.konstructed("flaky"), "A failed render must leave no model")
+
+        marker.writeText("go")
+
+        val second = service.konstruct("flaky")
+        assertEquals(
+            SUCCESS,
+            second.status,
+            "Re-requesting a failed target must re-run the render — a FAILURE here is the " +
+                "stale result being re-broadcast because render() was skipped. Result: $second"
+        )
+        assertNotNull(service.konstructed("flaky"), "The retry must produce a model")
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).targets.single { it.name == "flaky" }.state,
+            "The retried target must end up clean"
+        )
+    }
+}

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/FailedRenderRetryTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/FailedRenderRetryTest.kt
@@ -21,16 +21,22 @@ import com.monkopedia.konstructor.KonstructionServiceImpl
 import com.monkopedia.konstructor.common.DirtyState.CLEAN
 import com.monkopedia.konstructor.common.DirtyState.NEEDS_EXEC
 import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionCallbacks.RENDER_CHANGE
 import com.monkopedia.konstructor.common.KonstructionInfo
+import com.monkopedia.konstructor.common.TaskResult
 import com.monkopedia.konstructor.common.TaskStatus.FAILURE
 import com.monkopedia.konstructor.common.TaskStatus.SUCCESS
 import com.monkopedia.konstructor.logging.WarehouseWrapper
+import com.monkopedia.konstructor.testutil.FakeKonstructionListener
 import com.monkopedia.konstructor.testutil.TestEnvironment
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.encodeToStream
 import org.junit.After
@@ -47,6 +53,10 @@ import org.junit.Test
  * target CLEAN the guard in `KonstructionServiceImpl.konstruct()` skipped `render()` entirely
  * on the next request and just re-broadcast the stale failure — so re-running did nothing and
  * only an edit-and-recompile could clear it.
+ *
+ * Covered in both positions a target can be in: failing on its first render, and failing on a
+ * later one after it had already built and been recorded CLEAN. The second is the one that
+ * survives a fix which only asks "was it built?" and otherwise keeps the state it had.
  *
  * These drive the real pipeline (kotlinc + the script subprocess) through
  * [KonstructionServiceImpl], because the defect only shows up in the interaction between what
@@ -98,6 +108,8 @@ class FailedRenderRetryTest {
      */
     @Test
     fun failedTargetStaysDirtyWhileBuiltTargetGoesClean() = runBlocking {
+        val listener = FakeKonstructionListener(callbacks = listOf(RENDER_CHANGE))
+        service.register(listener)
         service.set(
             """
             val bad by primitive {
@@ -129,6 +141,152 @@ class FailedRenderRetryTest {
             "A target that failed at execute time must stay dirty so it can be retried. " +
                 "Targets: $targets"
         )
+
+        // The render deleted both STLs up front, so the failed target has no model any more
+        // and the editor has to be told — otherwise it keeps drawing geometry whose file is
+        // gone, and its own "have I got this render?" bookkeeping blocks a rebuild.
+        val renders = awaitRenders(listener, "bad", "good")
+        assertNotNull(
+            renders["good"],
+            "The built target must broadcast its model. Renders: $renders"
+        )
+        assertNull(
+            renders["bad"],
+            "The failed target must broadcast a null render to clear the stale model. " +
+                "Renders: $renders"
+        )
+    }
+
+    /**
+     * Wait for a render callback to arrive for each of [names] — they are dispatched on the
+     * service's own scope, so they land after `konstruct()` returns — and return the render
+     * path each one carried, by target name.
+     */
+    private suspend fun awaitRenders(
+        listener: FakeKonstructionListener,
+        vararg names: String
+    ): Map<String, String?> {
+        withTimeoutOrNull(5_000) {
+            while (!listener.renderChanges.map { it.name }.containsAll(names.toList())) {
+                delay(10)
+            }
+        }
+        val renders = listener.renderChanges.associate { it.name to it.renderPath }
+        assertTrue(
+            renders.keys.containsAll(names.toList()),
+            "Expected a render callback for each of ${names.toList()}, got $renders — a " +
+                "target whose model was deleted and never rebuilt is left uncleared."
+        )
+        return renders
+    }
+
+    /**
+     * The case the two tests above cannot reach: a target that already BUILT (so it is
+     * recorded CLEAN) and then fails on a later render.
+     *
+     * Deriving its state as "not built, so keep whatever it had" is only right for a target's
+     * first render — after that the state it had is CLEAN, and keeping it puts the target back
+     * in exactly the #104 hole. Failing at execute time must make it dirty again regardless of
+     * what it was before.
+     */
+    @Test
+    fun alreadyCleanTargetThatFailsBecomesDirtyAgain() = runBlocking {
+        val (_, second) = renderUntilACleanTargetFails()
+
+        assertEquals(FAILURE, second.status, "Second render must fail. Result: $second")
+        val targets = service.getInfo(Unit).targets.associate { it.name to it.state }
+        assertEquals(
+            CLEAN,
+            targets["bad"],
+            "The target that built on the second render must be clean. Targets: $targets"
+        )
+        assertEquals(
+            NEEDS_EXEC,
+            targets["other"],
+            "A target that failed at execute time must go dirty again even though it had " +
+                "already built once and was recorded CLEAN. Targets: $targets"
+        )
+    }
+
+    /**
+     * The end-to-end half of the same case: once a previously-clean target has failed, a
+     * re-request must re-enter `render()` rather than re-broadcast the stale failure.
+     *
+     * As above, nothing about the konstruction changes between the failing render and the
+     * retry — no edit, no recompile — so SUCCESS is only reachable by really rendering again.
+     */
+    @Test
+    fun reRequestRetriesATargetThatFailedAfterAlreadyBuilding() = runBlocking {
+        val (otherMarker, second) = renderUntilACleanTargetFails()
+        assertEquals(FAILURE, second.status, "Second render must fail. Result: $second")
+
+        otherMarker.delete()
+
+        val third = service.konstruct("other")
+        assertEquals(
+            SUCCESS,
+            third.status,
+            "A target that failed after already building must still be retriable — a FAILURE " +
+                "here is the stale result being re-broadcast because render() was skipped. " +
+                "Result: $third"
+        )
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).targets.single { it.name == "other" }.state,
+            "The retried target must end up clean"
+        )
+    }
+
+    /**
+     * Drives the two renders both of the tests above need: a first one that leaves `other`
+     * CLEAN and `bad` dirty, then a second (reached through `bad`, with the failures swapped
+     * out of band) in which the already-clean `other` fails at execute time.
+     *
+     * Returns `other`'s marker file — deleting it un-breaks the target — and the second
+     * render's result.
+     */
+    private suspend fun renderUntilACleanTargetFails(): Pair<File, TaskResult> {
+        val badMarker = File(env.tempDir, "break-bad")
+        val otherMarker = File(env.tempDir, "break-other")
+        service.set(
+            """
+            val bad by primitive {
+               if (java.io.File("${badMarker.absolutePath}").exists()) {
+                   throw RuntimeException("bad-boom")
+               }
+               cube {
+                   dimensions = xyz(1.0, 1.0, 1.0)
+               }
+            }
+            val other by primitive {
+               if (java.io.File("${otherMarker.absolutePath}").exists()) {
+                   throw RuntimeException("other-boom")
+               }
+               cube {
+                   dimensions = xyz(2.0, 2.0, 2.0)
+               }
+            }
+            export("bad")
+            export("other")
+            """.trimIndent()
+        )
+        assertEquals(SUCCESS, service.compile(Unit).status, "The script must compile")
+
+        badMarker.writeText("break")
+        val first = service.konstruct("bad")
+        assertEquals(FAILURE, first.status, "First render must fail. Result: $first")
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).targets.single { it.name == "other" }.state,
+            "Setup expects 'other' to have built and be clean before it starts failing"
+        )
+
+        // Swap which target is broken. No edit and no recompile, so the only thing that can
+        // change 'other' from clean to failed is the render itself.
+        badMarker.delete()
+        otherMarker.writeText("break")
+
+        return otherMarker to service.konstruct("bad")
     }
 
     /**

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/SubprocessFailureTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/SubprocessFailureTest.kt
@@ -307,7 +307,7 @@ class SubprocessFailureTest {
         paths.renderResultFile.outputStream().use { out ->
             cfg.json.encodeToStream(result, out)
         }
-        return executed
+        return executed.allTargets
     }
 
     /** Poll a non-blocking check of the coroutine Mutex until it is free. */

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecuteTaskTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecuteTaskTest.kt
@@ -55,7 +55,7 @@ class ExecuteTaskTest {
     }
 
     /**
-     * Regression test for #81.
+     * Regression test for #81 and #104.
      *
      * A multi-target render where one export fails at EXECUTE time (compiles fine, throws while
      * building/rendering) while the subprocess stays alive and another export succeeds. The
@@ -65,8 +65,11 @@ class ExecuteTaskTest {
      *       failure and the whole render reported SUCCESS (the failed target got marked CLEAN and
      *       never retried).
      *   (b) the fetched error trace was discarded, so `messages` was always empty.
+     *   (c) the reported target list was the *attempted* one, so the caller marked the failed
+     *       target CLEAN and never retried it (#104).
      *
-     * With the fix the render must report FAILURE and surface the error trace.
+     * With the fix the render must report FAILURE, surface the error trace, and report only
+     * the target that actually built.
      */
     @Test
     fun `multi-target render fails when one target fails at execute time`() {
@@ -93,6 +96,13 @@ class ExecuteTaskTest {
         assertTrue(
             result.messages.isNotEmpty(),
             "The execute-phase error trace must be surfaced in messages. Result: $result"
+        )
+        assertEquals(
+            listOf("good"),
+            result.taskArguments,
+            "Only targets that actually built may be reported (#104) — reporting the " +
+                "attempted list marks the failed target CLEAN, so it is never retried. " +
+                "Result: $result"
         )
     }
 

--- a/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructionServiceTypes.kt
+++ b/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructionServiceTypes.kt
@@ -39,6 +39,11 @@ data class TaskMessage(
 
 @Serializable
 data class TaskResult(
+    /**
+     * The targets this result covers: for a render, the targets that actually BUILT — a
+     * target that failed at execute time is absent, which is what keeps it dirty and
+     * retriable. Empty for a compile, which is not per-target.
+     */
     val taskArguments: List<String> = emptyList(),
     val status: TaskStatus,
     val messages: List<TaskMessage> = emptyList()


### PR DESCRIPTION
Fixes #104

## Scope — the owner's all-or-nothing ruling

This completes the **retry half** of that ruling. The owner ruled, verbatim: **"all or nothing sounds ok"** — a multi-target render is SUCCESS only if every exported target builds, a partial failure reports FAILURE, **and the failed target is left dirty so a later build retries it**. PR #92 implemented the FAILURE reporting (which is why it said `Refs`, not a closing keyword); the retry half was never implemented, and issue 104 tracks it. Per the ruling this adds **no** per-target/partial `TaskStatus` — the status stays all-or-nothing, only the *dirty state* becomes per-target-accurate.

The other half of issue 81 is already shipped and is not touched here.

## The defect

`KonstructionServiceImpl.konstruct()` derives dirty state from the render result's target list (`lastRenderResult().taskArguments`), and `ExecuteTask` reported the **attempted** list — `exports + validExtraTargets`, computed *before* the build loop. So a target that failed at execute time looked exactly like one that succeeded and landed `CLEAN`.

With it CLEAN, the next `requestKonstruct("bad")` fails the `dirtyState == NEEDS_EXEC || targets.any { … NEEDS_EXEC }` guard, skips `render()` entirely, and re-broadcasts the stale FAILURE. **Re-running does nothing** — only editing the script and forcing a recompile clears the failure. Nothing errors; the request is simply skipped.

## The fix

Dirty state after a render is now a three-way decision, because "never attempted" and "attempted and failed" want opposite answers:

| target | new state |
| --- | --- |
| built | `CLEAN` |
| attempted, did not build | `NEEDS_EXEC` |
| not attempted by this render | unchanged |

`ExecuteTask` reports the targets that **actually built** (previously the attempted list), and `render()` now returns `RenderedTargets(allTargets, attemptedTargets)` so the service can tell the middle row from the bottom one.

**Why the middle row needs to be explicit** (this was the first round's blocking review finding): deriving it as "not built, so keep the state it had" only works for a target's *first* render. After that the state it had is `CLEAN`, so an exported target that already built and then fails keeps `CLEAN` — straight back into the #104 hole, on a state **this PR is what starts producing** (one `CLEAN` target beside one `NEEDS_EXEC`). It is reachable with no flakiness at all: `ScriptHostImpl.findScript()` cross-konstruction imports mean breaking konstruction B makes A's already-clean target start failing with no edit to A, and subprocess death does the same per #84/#105.

**Render broadcast.** The `onRenderChanged` loop follows the attempted list, not the built one. `render()` deletes a target's STL before rebuilding it, so a target that then fails has no model, and the null broadcast is what tells the editor to drop it. Narrowing this loop to the built targets (as the first commit did) leaves `KonstructionViewModel` drawing geometry whose file is gone, and its `renderPaths` cache then short-circuits `if (renderPaths.containsKey(name)) return` — shutting the toggle-off/on rebuild route, a second retry path, inside a retryability fix. Net effect versus `main`: byte-identical broadcast set, corrected dirty state.

## Tests

`git grep NEEDS_EXEC -- backend/src/jvmTest e2e/src` returned nothing before this, so all of it is new. `FailedRenderRetryTest` drives the real pipeline — kotlinc plus the script subprocess — through `KonstructionServiceImpl`, in both positions a target can be in:

**First render** (the target has no prior state)
* `failedTargetStaysDirtyWhileBuiltTargetGoesClean` — both directions of the flag, plus the render broadcast: the built target reports its model, the failed one reports `null`.
* `reRequestOfAFailedTargetRunsTheRenderAgain` — the retry, end to end.

**Later render** (the target had already built and was recorded `CLEAN`)
* `alreadyCleanTargetThatFailsBecomesDirtyAgain` — the flag.
* `reRequestRetriesATargetThatFailedAfterAlreadyBuilding` — the retry, end to end.

The end-to-end pair is the point: the failure mode is silent — nothing errors, the request is simply skipped — so a test asserting only the dirty flag passes against a broken guard. In both, an out-of-band marker file is the *only* thing that changes between the failing render and the retry (no `set()`, no `compile()`), so `SUCCESS` is unreachable unless `render()` genuinely ran again.

`ExecuteTaskTest`'s existing #81 test also gains an assertion that only `good` is reported, not `[bad, good]`.

## Reverse-apply proofs (build slot, `:backend:jvmTest` executed, XML deleted first)

Each disables **one branch** of the fix, leaving `RenderedTargets`, the tests, and every API they compile against in place — a real test failure, not a compile error.

**1. The middle row** — `attempted and not built -> NEEDS_EXEC` reverted to `existingTargets[target]?.state ?: NEEDS_EXEC` (the first commit's rule). `7 tests completed, 2 failed`:

```
FAILED: alreadyCleanTargetThatFailsBecomesDirtyAgain (4.235s)
  AssertionError: A target that failed at execute time must go dirty again even though it
  had already built once and was recorded CLEAN. Targets: {bad=CLEAN, other=CLEAN}
  expected:<NEEDS_EXEC> but was:<CLEAN>

FAILED: reRequestRetriesATargetThatFailedAfterAlreadyBuilding (4.236s)
  AssertionError: A target that failed after already building must still be retriable — a
  FAILURE here is the stale result being re-broadcast because render() was skipped.
  Result: TaskResult(taskArguments=[bad], status=FAILURE, messages=[…other-boom…])
```

Same two lines the review reproduced independently. Note the two first-render tests **passed** under this disable — confirming the review's point that they structurally cannot reach this case, and that the new pair is what covers it.

**2. The broadcast** — the loop pointed back at `latestBuilt`. `7 tests completed, 1 failed`:

```
FAILED: failedTargetStaysDirtyWhileBuiltTargetGoesClean (8.737s)
  AssertionError: Expected a render callback for each of [bad, good], got
  {good=model/ws1/k1/renders/good.stl} — a target whose model was deleted and never
  rebuilt is left uncleared.
```

**Green, twice.** `./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true`, XML deleted before each, both test tasks executed rather than UP-TO-DATE: **backend 141 tests / 0 failures / 6 skipped** (the LSP engine-dependent ones — the local `intellij-server` build has expired, pre-existing), **protocol 17 / 0 / 0**, identical across both runs. All four `FailedRenderRetryTest` methods appear in the fresh XML as run, not skipped (3.4–5.1s of real kotlinc+subprocess work each).

## What this deliberately does not do

* **`info.dirtyState` is still set to `CLEAN` unconditionally, even when the render failed** (`:299`). Flagged in review as pre-existing and non-blocking, and left alone on purpose: the per-target clause of the guard is what carries the retry, and the obvious "dirty if any target is dirty" rewrite would pin `dirtyState` to `NEEDS_EXEC` forever for any script with a declared-but-never-exported target. That deserves its own issue rather than a drive-by here.
* **Konstructions already stuck in the #104 state on the live instance stay stuck.** This fixes the state transition going forward, not the `CLEAN` already written to `info.json` by an older build; those clear on their next edit+recompile. No migration is attempted.
* **No third `TaskStatus`, and no new protocol field.** The only `protocol/` change in this PR is a KDoc; the review round-tripped prod-shape `info.json`, a legacy one with no `targets` key, and a prod-shape render result (`TaskResult` is itself persisted) and found all of them clean and downgrade-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
