### PR TITLE
test(backend): cover the info.json writer the suite was blind to

### DIFF
--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/ConcurrentCreateTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/ConcurrentCreateTest.kt
@@ -17,8 +17,15 @@
 
 package com.monkopedia.konstructor
 
+import com.monkopedia.konstructor.common.DirtyState
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionInfo
 import com.monkopedia.konstructor.common.Space
 import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -229,12 +236,69 @@ class ConcurrentCreateTest {
         )
     }
 
+    @Test
+    fun aListingNeverSeesTheControllersInfoFileHalfWritten() {
+        // The writer that #102 actually reported, and the one the rest of this class is
+        // BLIND to. Measured during the #111 review: revert KonstructionController's write
+        // to the in-place form and all five other tests here still pass, while 451 of 1299
+        // concurrent listings fail with #102's verbatim string —
+        // `Expected colon ':', but had 'EOF' instead at path: $konstruction`. The other
+        // tests exercise writeInfo and createWithClaimedId directly; none goes through the
+        // controller, which is exactly how this writer was missed for two rounds.
+        val root = env.tempDir
+        val wsDir = File(root, "ws1").also { it.mkdirs() }
+        writeInfo(File(wsDir, INFO_JSON), env.config.json, Space(id = "ws1", name = "ws"))
+        val kDir = File(wsDir, "k1").also { it.mkdirs() }
+        val base = KonstructionInfo(
+            Konstruction(name = "k", workspaceId = "ws1", id = "k1"),
+            DirtyState.CLEAN,
+            emptyList()
+        )
+        writeInfo(File(kDir, INFO_JSON), env.config.json, base)
+
+        // Unconfined so the setter's write happens inline rather than on its own thread —
+        // otherwise the loop below outruns the writes and the probe races nothing.
+        val controller =
+            KonstructionControllerImpl(env.config, "ws1", "k1", Dispatchers.Unconfined)
+        val listings = AtomicInteger()
+        val failures = AtomicInteger()
+        val stop = AtomicBoolean(false)
+        val pool = Executors.newFixedThreadPool(1)
+        try {
+            pool.submit {
+                while (!stop.get()) {
+                    listings.incrementAndGet()
+                    runCatching { wsDir.listInfo<KonstructionInfo>(env.config.json) }
+                        .onFailure { failures.incrementAndGet() }
+                }
+            }
+            val padding = "n".repeat(2_000)
+            repeat(CONTROLLER_WRITES) { n ->
+                controller.info =
+                    base.copy(konstruction = base.konstruction.copy(name = "$padding-$n"))
+            }
+        } finally {
+            stop.set(true)
+            pool.shutdown()
+            pool.awaitTermination(30, TimeUnit.SECONDS)
+        }
+
+        assertEquals(
+            0,
+            failures.get(),
+            "${failures.get()} of ${listings.get()} listings saw a torn info.json — the " +
+                "controller's write is no longer atomic (konstructor#102)."
+        )
+        assertTrue(listings.get() > 100, "the probe only proves something if it listed a lot")
+    }
+
     private companion object {
         const val RACERS = 8
         const val ROUNDS = 25
         const val REWRITES = 400
         const val WRITERS = 4
         const val WRITES_EACH = 300
+        const val CONTROLLER_WRITES = 800
 
         /** Big enough that a truncated write is very likely to land mid-token. */
         val PADDING = "n".repeat(2_000)


### PR DESCRIPTION
Fixes #114

## The gap

PR #111 routed `KonstructionController.info`'s setter through `writeInfo` — that setter writes the konstruction's own `info.json`, which is exactly what `WorkspaceImpl.list()` decodes, and it fires on rename, dirty-state changes and target updates. It is the writer issue #102 actually reported, identifiable from the reported error naming `at path: $.konstruction`.

**It shipped with no test, and the review measured that the suite cannot see its regression:** revert that one line and all five `ConcurrentCreateTest` cases stay green while 451 of 1299 concurrent listings fail (35%).

That blindness is not incidental — **it is how the writer was missed for two rounds.** #111's earlier passes fixed `createWithClaimedId` and `WorkspaceImpl.setName`, both exercised directly by tests, and nothing failed. The one writer nothing drove was the one the issue was about.

## What the test does

Drives the **real `KonstructionControllerImpl`** on `Dispatchers.Unconfined`, so the setter's write happens inline — otherwise the reader loop outruns the writes and the probe races nothing at all. A background reader lists the workspace continuously while 800 padded writes go through the controller.

It asserts **zero** torn listings rather than a reduced rate, because an atomic move leaves no window whatsoever, and it asserts the reader got past a hundred listings so a probe that measured nothing cannot pass trivially.

## Demonstrated RED

Reverting only the controller's write back to the in-place form, API and every other test intact:

```
aListingNeverSeesTheControllersInfoFileHalfWritten FAILED
552 of 1466 listings saw a torn info.json — the controller's write is no longer
atomic (konstructor#102). expected:<0> but was:<552>
```

The other five cases in that class stayed green throughout, which is the point.

## Verification

`spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` — **162 tests, 0 failures, 6 skipped**, twice before the rebase and once after, XML deleted first with fresh mtimes confirmed.

## Notes for the reviewer

- Test-only; no production change. The behaviour it guards merged in #111 (`56ff9c0`).
- Post your verdict as a **review object** (`gh pr review …`) via the reviewer bot — even a held outcome. A verdict as a plain comment pins to no SHA.
- `main` is unprotected, so `--auto` is not a CI gate — poll `gh pr checks` to completed SUCCESS, then plain `--squash --delete-branch`.
- Worth challenging: `Dispatchers.Unconfined` makes the write inline and therefore deterministic, but it also means this does not exercise the real `newSingleThreadContext` save path. If you think a version that races the actual async setter would catch more, say so — I chose determinism over fidelity here and that is arguable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)