### PR TITLE
fix(konstruct): don't read result.json when the render was skipped (#120)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
@@ -56,6 +56,11 @@ interface KonstructionController {
     suspend fun compile()
     suspend fun lastCompileResult(): TaskResult
     suspend fun render(targets: List<String>): List<String>
+
+    /** Whether a render has ever completed, i.e. whether [lastRenderResult] has one to read. */
+    suspend fun hasRenderResult(): Boolean
+
+    /** The result of the last [render]; only valid when [hasRenderResult] is true. */
     suspend fun lastRenderResult(): TaskResult
     suspend fun renderFile(target: String): File?
 }
@@ -139,6 +144,10 @@ class KonstructionControllerImpl(
             }
             return executedTargets
         }
+    }
+
+    override suspend fun hasRenderResult(): Boolean = withContext(Dispatchers.IO) {
+        paths.renderResultFile.exists()
     }
 
     override suspend fun lastRenderResult(): TaskResult = withContext(Dispatchers.IO) {

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -35,7 +35,9 @@ import com.monkopedia.konstructor.common.KonstructionListener
 import com.monkopedia.konstructor.common.KonstructionRender
 import com.monkopedia.konstructor.common.KonstructionService
 import com.monkopedia.konstructor.common.KonstructionTarget
+import com.monkopedia.konstructor.common.TaskMessage
 import com.monkopedia.konstructor.common.TaskResult
+import com.monkopedia.konstructor.common.TaskStatus.FAILURE
 import com.monkopedia.konstructor.common.TaskStatus.SUCCESS
 import com.monkopedia.konstructor.logging.LoggingService
 import com.monkopedia.konstructor.logging.WarehouseWrapper
@@ -61,6 +63,10 @@ import kotlinx.coroutines.withTimeout
 
 /** Upper bound on a single compile/konstruct/listener-callback before it's cancelled. */
 private val callTimeout = 120.seconds
+
+/** Reported by `konstruct` when there was nothing to render and nothing had ever been built. */
+private const val NOTHING_RENDERED =
+    "Nothing was built: this konstruction has no render yet. Compile it first."
 
 class KonstructionServiceImpl(
     private val config: Config,
@@ -300,12 +306,33 @@ class KonstructionServiceImpl(
                     }
                 }
             }
-            konstructionController.lastRenderResult().also { result ->
+            renderResult().also { result ->
                 broadcast {
                     onTaskComplete(result)
                 }
             }
         }
+
+    /**
+     * The result to report for a konstruct.
+     *
+     * Normally that is the last render's result — on the skip path the requested targets are
+     * already up to date, so the render that made them clean is the honest answer, and callers
+     * rely on an already-built target still reporting SUCCESS.
+     *
+     * A konstruction that has never rendered has no `result.json` at all, though, and reading
+     * it threw [java.io.FileNotFoundException] out of an ordinary `konstruct()` (#120). It
+     * can't be reported as an empty success either: nothing was built, and claiming otherwise
+     * turns the crash into a quiet wrong answer. Say what actually happened instead.
+     */
+    private suspend fun renderResult(): TaskResult = if (konstructionController.hasRenderResult()) {
+        konstructionController.lastRenderResult()
+    } else {
+        TaskResult(
+            status = FAILURE,
+            messages = listOf(TaskMessage(NOTHING_RENDERED))
+        )
+    }
 
     override suspend fun requestKonstruct(target: String): Unit =
         callContext("requestKonstruct", baseCallSign = konstructionController.callSign) {

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionServiceKonstructTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionServiceKonstructTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.monkopedia.konstructor
+
+import com.monkopedia.konstructor.common.DirtyState
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionInfo
+import com.monkopedia.konstructor.common.TaskResult
+import com.monkopedia.konstructor.common.TaskStatus
+import com.monkopedia.konstructor.logging.WarehouseWrapper
+import com.monkopedia.konstructor.testutil.FakeKonstructionListener
+import com.monkopedia.konstructor.testutil.TestEnvironment
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.encodeToStream
+
+/**
+ * What `konstruct` reports when its dirty-state guard decides there is nothing to render.
+ *
+ * A konstruction is created CLEAN with no targets ([WorkspaceImpl.create]), so a konstruct
+ * request that arrives before anything has been compiled skips the render — deterministically,
+ * with no timing involved. `konstruct` used to read `result.json` regardless, which in that
+ * state does not exist, so an ordinary call died with `FileNotFoundException` (#120).
+ */
+class KonstructionServiceKonstructTest {
+
+    private lateinit var env: TestEnvironment
+    private lateinit var scriptDir: File
+    private lateinit var service: KonstructionServiceImpl
+
+    @BeforeTest
+    fun setUp() {
+        env = TestEnvironment()
+        env.createWorkspaceDir("ws1", "Test")
+        scriptDir = File(env.tempDir, "ws1/k1").also { it.mkdirs() }
+        // Exactly what WorkspaceImpl.create() writes: CLEAN, no targets, no render.
+        val info = KonstructionInfo(
+            Konstruction(name = "test", workspaceId = "ws1", id = "k1"),
+            DirtyState.CLEAN
+        )
+        File(scriptDir, "info.json").outputStream().use {
+            env.config.json.encodeToStream(info, it)
+        }
+        service = KonstructionServiceImpl(
+            config = env.config,
+            workspaceId = "ws1",
+            id = "k1",
+            warehouseWrapper = WarehouseWrapper(),
+            onClose = {}
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        env.close()
+    }
+
+    private suspend fun awaitTaskComplete(listener: FakeKonstructionListener): TaskResult {
+        withTimeout(5_000) {
+            while (listener.taskCompletes.isEmpty()) {
+                delay(10)
+            }
+        }
+        return listener.taskCompletes.single()
+    }
+
+    @Test
+    fun skippedRenderWithNoPriorRenderReportsFailureRatherThanThrowing() = runBlocking {
+        assertTrue(
+            !File(scriptDir, "result.json").exists(),
+            "precondition: nothing has ever been rendered"
+        )
+        val listener = FakeKonstructionListener()
+        service.register(listener)
+
+        val result = service.konstruct("simpleCube")
+
+        assertEquals(TaskStatus.FAILURE, result.status, "nothing was built")
+        assertEquals(emptyList(), result.taskArguments, "no target was built")
+        assertTrue(result.messages.isNotEmpty(), "the caller must be told why: $result")
+        // The frontend leaves its spinner up until onTaskComplete lands (see
+        // KonstructionViewModel.setTargetEnabled), so the broadcast still has to fire.
+        assertEquals(result, awaitTaskComplete(listener), "onTaskComplete payload")
+    }
+
+    @Test
+    fun skippedRenderReportsThePriorRenderResult() = runBlocking {
+        val previous = TaskResult(listOf("simpleCube"), TaskStatus.SUCCESS)
+        File(scriptDir, "result.json").outputStream().use {
+            env.config.json.encodeToStream(previous, it)
+        }
+        val listener = FakeKonstructionListener()
+        service.register(listener)
+
+        // Already built and unchanged: konstruct still answers with that render, so a
+        // caller re-requesting an up-to-date target keeps seeing SUCCESS.
+        val result = service.konstruct("simpleCube")
+
+        assertEquals(previous, result, "prior render result")
+        assertEquals(previous, awaitTaskComplete(listener), "onTaskComplete payload")
+    }
+}


### PR DESCRIPTION
Fixes #120

## The defect

`konstruct()` ended by reading the last render result to broadcast `onTaskComplete`, **outside** the dirty-state guard. When the guard skips the render and the konstruction has never rendered, there is no `result.json`, so an ordinary `konstruct()` died with `FileNotFoundException`.

## Deterministic reproduction (no load, no timing)

`WorkspaceImpl.create()` writes a konstruction as `CLEAN` with no targets. So a `konstruct()` that arrives before anything is compiled always skips the guard and always reads a file that was never written. The new test constructs exactly that state directly — the old reproduction needed the full suite under CPU pressure, and this one does not depend on the unexplained suite-level interference tracked in the separate #104 report.

RED, with the fix surgically disabled (guard condition forced true, API unchanged so the test still compiles):

```
KonstructionServiceKonstructTest > skippedRenderWithNoPriorRenderReportsFailureRatherThanThrowing FAILED
    java.io.FileNotFoundException: /tmp/konstructor-test-.../ws1/k1/result.json (No such file or directory)
      at KonstructionControllerImpl$lastRenderResult$2.invokeSuspend(KonstructionController.kt:154)
      at KonstructionServiceImpl$konstruct...
2 tests completed, 1 failed
```

The sibling test (`skippedRenderReportsThePriorRenderResult`) passed in the same RED run, which is what shows the failure is the defect rather than a broken build.

## Which shape, and why

The issue offers two shapes. I measured what the callers need before picking.

**"Return early on the skip path, before the broadcast" — rejected: it breaks the frontend.** `KonstructionViewModel` sets `UiState.EXECUTING` and then relies on `onTaskComplete` to settle it back to `DEFAULT`:

- `setTargetEnabled()` — comment in-tree: *"onRenderChanged will populate renderPaths, and onTaskComplete resets _state to DEFAULT"*.
- `save()` → `requestKonstructs()` — fire-and-forget, so the return value is not even seen; only `onTaskComplete` (or an `onInfoChanged` that the skip path also does not send) clears the spinner.

Suppressing the broadcast for a no-op konstruct would hang the UI in EXECUTING. So the broadcast has to keep firing.

**"Report honestly" — taken, with the read made conditional rather than the result fabricated:**

- **A render result exists** → keep returning it. On the skip path the requested targets are already up to date, so the render that made them clean is the honest answer, and callers rely on re-requesting an already-built target still reporting SUCCESS (`BuildAndDownloadStlTest.testMultipleTargetsBuildAndDownload` builds `myCube` then `mySphere`; the second call skips because the first render built both, and asserts SUCCESS). Locked down by the second new test.
- **No render result at all** → `FAILURE` with a message saying nothing was built, `taskArguments` empty. This is the trap the issue warns about, avoided: an empty `SUCCESS` here would be a fabricated success for work that did not happen, and the caller's postcondition (the requested target is built) is genuinely not met. The message surfaces in the frontend's messages pane via `_messages.value = result.messages`.

No protocol/signature change was needed for that, so `TaskStatus` is untouched. **Fallback if a reviewer disagrees:** add a distinct third `TaskStatus` (e.g. `SKIPPED`) for the no-prior-render case. I did not, because `FAILURE` + message already distinguishes it from a successful render, tells the caller *why*, and does not force a new branch into every existing `status ==` check — while a `SKIPPED` value would have to be returned *only* in the no-prior-render sub-case to avoid breaking the already-built-target contract above, making the enum value oddly asymmetric.

## Implementation

`KonstructionController.hasRenderResult()` (a `renderResultFile.exists()` check, mirroring the existing `renderFile()` exists-checks) gates the read. `lastRenderResult()` stays non-null — making it nullable would have forced a `!!` at the in-guard call site right after `render()`, where a result always exists.

## Scope

Only the unconditional read. Nothing here touches the failed-target-staying-CLEAN behaviour or the suite interference described in #104 — that work was reverted and is being handled separately.

## Verification

`./gradlew spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true` → BUILD SUCCESSFUL, both test tasks executed (not UP-TO-DATE). Fresh XML: backend 149 tests / 6 skipped / 0 failures / 0 errors, protocol 17 / 0 / 0 / 0.
