### PR TITLE
Re-land: keep a failed render target dirty so re-running retries it (#104)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
@@ -44,6 +44,15 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 
+/**
+ * What a render touched.
+ *
+ * [attemptedTargets] is the subset of [allTargets] the render actually tried to build — the
+ * script's exports plus any requested extras that exist. Which of those succeeded is reported
+ * separately, in the render's [TaskResult.taskArguments].
+ */
+data class RenderedTargets(val allTargets: List<String>, val attemptedTargets: List<String>)
+
 interface KonstructionController {
     val callSign: CallSign
     val paths: PathController.Paths
@@ -55,7 +64,7 @@ interface KonstructionController {
     suspend fun write(content: ByteReadChannel)
     suspend fun compile()
     suspend fun lastCompileResult(): TaskResult
-    suspend fun render(targets: List<String>): List<String>
+    suspend fun render(targets: List<String>): RenderedTargets
 
     /** Whether a render has ever completed, i.e. whether [lastRenderResult] has one to read. */
     suspend fun hasRenderResult(): Boolean
@@ -127,7 +136,7 @@ class KonstructionControllerImpl(
         }
     }
 
-    override suspend fun render(targets: List<String>): List<String> {
+    override suspend fun render(targets: List<String>): RenderedTargets {
         contentFileLock.withLock {
             for (target in targets) {
                 val targetFile = File(paths.renderOutput, "$target.stl")
@@ -144,11 +153,11 @@ class KonstructionControllerImpl(
                 extraTargets = targets,
                 subprocessExit = scriptExit
             )
-            val (result, executedTargets) = executeTask.execute()
+            val (result, renderedTargets) = executeTask.execute()
             paths.renderResultFile.outputStream().use { output ->
                 config.json.encodeToStream(result, output)
             }
-            return executedTargets
+            return renderedTargets
         }
     }
 

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionController.kt
@@ -88,7 +88,15 @@ class KonstructionControllerImpl(
         }
         set(value) {
             if (infoImpl == value) return
-            // Optimistically set now, to have the info available immediately.
+            // The in-memory value is published HERE, synchronously, and nowhere else. The
+            // persist below used to repeat `infoImpl = value` after its write "to settle out
+            // any race conditions", which did the opposite: the job captures the value it was
+            // launched with, so a slow write resurrected stale info over a newer assignment.
+            // `compile()` holds contentFileLock for the whole compile, so the job launched by
+            // the preceding `set()` was still queued on that lock when compile() published
+            // NEEDS_EXEC — and then overwrote it with NEEDS_COMPILE. A konstruct() landing in
+            // that window read the stale state, skipped render() and reported a render that
+            // never happened (#122).
             infoImpl = value
             GlobalScope.launch(saveContext + callSign) {
                 runCatching {
@@ -100,8 +108,6 @@ class KonstructionControllerImpl(
                         writeInfo(paths.infoFile, config.json, value)
                     }
                 }.onFailure { hauler.error("Failed to persist info for $workspaceId/$id", it) }
-                // Always set one more time after write to settle out any race conditions.
-                infoImpl = value
             }
         }
     override val scriptLock: Mutex = Mutex()

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -269,17 +269,24 @@ class KonstructionServiceImpl(
             if (info.dirtyState == NEEDS_EXEC ||
                 info.targets.any { it.name in targets && it.state == NEEDS_EXEC }
             ) {
-                val allTargets = konstructionController.render(targets)
+                val rendered = konstructionController.render(targets)
                 val latestBuilt = konstructionController.lastRenderResult().taskArguments
                 val existingTargets = info.targets.associateBy { it.name }
                 val changedTargets = mutableListOf<KonstructionTarget>()
-                val targets = allTargets.map { target ->
-                    val dirtyState =
-                        if (target in latestBuilt) {
-                            CLEAN
-                        } else {
-                            existingTargets[target]?.state ?: NEEDS_EXEC
-                        }
+                val targets = rendered.allTargets.map { target ->
+                    val dirtyState = when {
+                        target in latestBuilt -> CLEAN
+
+                        // Attempted but not built: leave it dirty so the guard above lets a
+                        // later request re-enter render(). Keeping its previous state would
+                        // record a target that had already built as CLEAN even though its
+                        // render just failed, and the retry would be skipped in favour of
+                        // re-broadcasting the stale failure (#104).
+                        target in rendered.attemptedTargets -> NEEDS_EXEC
+
+                        // Untouched by this render, so its state is still whatever it was.
+                        else -> existingTargets[target]?.state ?: NEEDS_EXEC
+                    }
                     existingTargets[target]?.let {
                         if (it.state != dirtyState) {
                             it.copy(state = dirtyState).also(changedTargets::add)
@@ -295,12 +302,16 @@ class KonstructionServiceImpl(
                 konstructionController.info = newInfo
                 broadcast {
                     onInfoChanged(newInfo, changedTargets)
-                    for (rendered in latestBuilt) {
+                    // Every attempted target, not only the built ones: render() deleted the
+                    // STL of each target it was asked for, so one that then failed to build
+                    // must broadcast a null render (konstructed() finds no file) to clear the
+                    // geometry the editor is still showing for it.
+                    for (attempted in rendered.attemptedTargets) {
                         onRenderChanged(
                             KonstructionRender(
                                 info.konstruction,
-                                rendered,
-                                konstructed(rendered)
+                                attempted,
+                                konstructed(attempted)
                             )
                         )
                     }

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecuteTask.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecuteTask.kt
@@ -20,6 +20,7 @@ import com.monkopedia.hauler.error
 import com.monkopedia.hauler.hauler
 import com.monkopedia.hauler.info
 import com.monkopedia.konstructor.Config
+import com.monkopedia.konstructor.RenderedTargets
 import com.monkopedia.konstructor.common.MessageImportance
 import com.monkopedia.konstructor.common.TaskMessage
 import com.monkopedia.konstructor.common.TaskResult
@@ -58,14 +59,15 @@ class ExecuteTask(
     private val subprocessExit: Deferred<Int>? = null
 ) {
     private val hauler by lazy { hauler() }
-    suspend fun execute(): Pair<TaskResult, List<String>> {
+    suspend fun execute(): Pair<TaskResult, RenderedTargets> {
         val messages = mutableListOf<TaskMessage>()
         var isSuccessful = true
         val exports = script.listTargets(onlyExports = true)
         val allTargets = script.listTargets(onlyExports = false).map { it.name }
         val validExtraTargets = extraTargets.filter { it in allTargets }
-        val builtTargets = (exports.map { it.name } + validExtraTargets).distinct()
-        for (export in builtTargets) {
+        val attemptedTargets = (exports.map { it.name } + validExtraTargets).distinct()
+        val builtTargets = mutableListOf<String>()
+        for (export in attemptedTargets) {
             hauler.debug("Starting building $export")
             val exportService = script.buildTarget(export)
             val status = awaitTerminalStatus(export, exportService)
@@ -73,10 +75,14 @@ class ExecuteTask(
             val targetBuilt = status == BUILT
             // Accumulate — one failed target must fail the whole render. This previously
             // ASSIGNED (`isSuccessful = status == BUILT`), i.e. last-target-wins: with a live
-            // subprocess, target A failing then target B succeeding reported SUCCESS and the
-            // caller marked the failed target CLEAN, so it never retried (#81).
+            // subprocess, target A failing then target B succeeding reported SUCCESS (#81).
             isSuccessful = isSuccessful && targetBuilt
-            if (!targetBuilt) {
+            if (targetBuilt) {
+                // Only targets that actually built are reported. The caller derives dirty
+                // state from this list, so a failed target must be left out of it to stay
+                // NEEDS_EXEC and be retried by a later render (#104).
+                builtTargets += export
+            } else {
                 val trace = runCatching { exportService.getErrorTrace() }.getOrNull()
                 hauler.error("Error: $trace")
                 // Surface the execute-phase error to the UI. The trace is a runtime error,
@@ -111,7 +117,7 @@ class ExecuteTask(
             builtTargets,
             if (isSuccessful) SUCCESS else FAILURE,
             messages
-        ) to allTargets
+        ) to RenderedTargets(allTargets, attemptedTargets)
     }
 
     /**

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionControllerConcurrencyTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionControllerConcurrencyTest.kt
@@ -22,9 +22,11 @@ import com.monkopedia.konstructor.common.Konstruction
 import com.monkopedia.konstructor.common.KonstructionInfo
 import com.monkopedia.konstructor.testutil.TestEnvironment
 import java.io.File
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -115,6 +117,52 @@ class KonstructionControllerConcurrencyTest {
             controller.write("survivor")
             assertEquals("survivor", controller.read())
         }
+    }
+
+    /**
+     * Regression for #122: a queued persist must not publish the info it captured over a
+     * newer assignment.
+     *
+     * The setter publishes the value synchronously and then persists it asynchronously. The
+     * persist used to end by repeating `infoImpl = value` "to settle out any race conditions",
+     * which did the opposite — each job captures the value it was launched with, so a job
+     * still queued when a later assignment landed resurrected the older one.
+     *
+     * The window is real in production: `compile()` holds the content lock for the whole
+     * kotlinc run and the persist needs the same lock, so the job launched by `set()`
+     * (NEEDS_COMPILE) was still waiting on it when `compile()` published NEEDS_EXEC. A
+     * `konstruct()` reading the resurrected NEEDS_COMPILE failed the dirty-state guard and
+     * skipped `render()` entirely.
+     *
+     * Draining the save dispatcher by hand makes that interleaving exact rather than
+     * load-dependent: after every persist runs, the info must still be the newest assigned.
+     */
+    @Test
+    fun aQueuedPersistDoesNotResurrectOlderInfo() = runBlocking {
+        val queue = ArrayDeque<Runnable>()
+        val queueing = object : CoroutineDispatcher() {
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                synchronized(queue) { queue.addLast(block) }
+            }
+        }
+        val controller = KonstructionControllerImpl(env.config, "ws1", "k1", queueing)
+
+        controller.info = controller.info.copy(dirtyState = DirtyState.NEEDS_COMPILE)
+        controller.info = controller.info.copy(dirtyState = DirtyState.NEEDS_EXEC)
+
+        val observed = mutableListOf<DirtyState>()
+        var guard = 0
+        while (guard++ < 100) {
+            val next = synchronized(queue) { queue.removeFirstOrNull() } ?: break
+            next.run()
+            observed += controller.info.dirtyState
+        }
+
+        assertTrue(observed.isNotEmpty(), "The setter must have queued a persist to drain")
+        assertTrue(
+            observed.all { it == DirtyState.NEEDS_EXEC },
+            "A persist must never publish the info it captured over a newer one. Saw: $observed"
+        )
     }
 
     @Test

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/FailedRenderRetryTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/FailedRenderRetryTest.kt
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.monkopedia.konstructor.integration
+
+import com.monkopedia.konstructor.KonstructionServiceImpl
+import com.monkopedia.konstructor.common.DirtyState.CLEAN
+import com.monkopedia.konstructor.common.DirtyState.NEEDS_EXEC
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionCallbacks.RENDER_CHANGE
+import com.monkopedia.konstructor.common.KonstructionInfo
+import com.monkopedia.konstructor.common.TaskResult
+import com.monkopedia.konstructor.common.TaskStatus.FAILURE
+import com.monkopedia.konstructor.common.TaskStatus.SUCCESS
+import com.monkopedia.konstructor.logging.WarehouseWrapper
+import com.monkopedia.konstructor.testutil.FakeKonstructionListener
+import com.monkopedia.konstructor.testutil.TestEnvironment
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.encodeToStream
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Coverage for #104: a target that fails at execute time must stay dirty so a later request
+ * retries it.
+ *
+ * #81 made a partial render report FAILURE, but the failed target was still recorded CLEAN
+ * (dirty state came from the *attempted* target list, not from what actually built). With the
+ * target CLEAN the guard in `KonstructionServiceImpl.konstruct()` skipped `render()` entirely
+ * on the next request and just re-broadcast the stale failure — so re-running did nothing and
+ * only an edit-and-recompile could clear it.
+ *
+ * Covered in both positions a target can be in: failing on its first render, and failing on a
+ * later one after it had already built and been recorded CLEAN. The second is the one that
+ * survives a fix which only asks "was it built?" and otherwise keeps the state it had.
+ *
+ * These drive the real pipeline (kotlinc + the script subprocess) through
+ * [KonstructionServiceImpl], because the defect only shows up in the interaction between what
+ * `ExecuteTask` reports and how the service turns it into dirty state.
+ */
+class FailedRenderRetryTest {
+
+    private lateinit var env: TestEnvironment
+    private lateinit var service: KonstructionServiceImpl
+
+    @Before
+    fun setUp() {
+        // Needs the full build (lib shadowJar bundled into backend resources), same as the
+        // other compile+execute integration tests.
+        assumeTrue(
+            "Set -Dintegration=true to run compile integration tests",
+            System.getProperty("integration") == "true"
+        )
+        env = TestEnvironment()
+        env.createWorkspaceDir("ws1", "Test")
+        val dir = File(env.tempDir, "ws1/k1")
+        dir.mkdirs()
+        val info = KonstructionInfo(
+            Konstruction(name = "test", workspaceId = "ws1", id = "k1"),
+            CLEAN
+        )
+        File(dir, "info.json").outputStream().use {
+            env.config.json.encodeToStream(info, it)
+        }
+        service = KonstructionServiceImpl(
+            config = env.config,
+            workspaceId = "ws1",
+            id = "k1",
+            warehouseWrapper = WarehouseWrapper(),
+            onClose = {}
+        )
+    }
+
+    @After
+    fun tearDown() {
+        if (::env.isInitialized) {
+            env.close()
+        }
+    }
+
+    /**
+     * Both directions of the dirty state a render leaves behind: the target that built is
+     * CLEAN, the target that failed is still NEEDS_EXEC.
+     */
+    @Test
+    fun failedTargetStaysDirtyWhileBuiltTargetGoesClean() = runBlocking {
+        val listener = FakeKonstructionListener(callbacks = listOf(RENDER_CHANGE))
+        service.register(listener)
+        service.set(
+            """
+            val bad by primitive {
+               throw RuntimeException("boom-104")
+            }
+            val good by primitive {
+               cube {
+                   dimensions = xyz(1.0, 1.0, 1.0)
+               }
+            }
+            export("bad")
+            export("good")
+            """.trimIndent()
+        )
+        assertEquals(SUCCESS, service.compile(Unit).status, "The script must compile")
+
+        val result = service.konstruct("bad")
+        assertEquals(FAILURE, result.status, "Render result: $result")
+
+        val targets = service.getInfo(Unit).targets.associate { it.name to it.state }
+        assertEquals(
+            CLEAN,
+            targets["good"],
+            "A target that built must be marked clean. Targets: $targets"
+        )
+        assertEquals(
+            NEEDS_EXEC,
+            targets["bad"],
+            "A target that failed at execute time must stay dirty so it can be retried. " +
+                "Targets: $targets"
+        )
+
+        // The render deleted both STLs up front, so the failed target has no model any more
+        // and the editor has to be told — otherwise it keeps drawing geometry whose file is
+        // gone, and its own "have I got this render?" bookkeeping blocks a rebuild.
+        val renders = awaitRenders(listener, "bad", "good")
+        assertNotNull(
+            renders["good"],
+            "The built target must broadcast its model. Renders: $renders"
+        )
+        assertNull(
+            renders["bad"],
+            "The failed target must broadcast a null render to clear the stale model. " +
+                "Renders: $renders"
+        )
+    }
+
+    /**
+     * Wait for a render callback to arrive for each of [names] — they are dispatched on the
+     * service's own scope, so they land after `konstruct()` returns — and return the render
+     * path each one carried, by target name.
+     */
+    private suspend fun awaitRenders(
+        listener: FakeKonstructionListener,
+        vararg names: String
+    ): Map<String, String?> {
+        withTimeoutOrNull(5_000) {
+            while (!listener.renderChanges.map { it.name }.containsAll(names.toList())) {
+                delay(10)
+            }
+        }
+        val renders = listener.renderChanges.associate { it.name to it.renderPath }
+        assertTrue(
+            renders.keys.containsAll(names.toList()),
+            "Expected a render callback for each of ${names.toList()}, got $renders — a " +
+                "target whose model was deleted and never rebuilt is left uncleared."
+        )
+        return renders
+    }
+
+    /**
+     * The case the two tests above cannot reach: a target that already BUILT (so it is
+     * recorded CLEAN) and then fails on a later render.
+     *
+     * Deriving its state as "not built, so keep whatever it had" is only right for a target's
+     * first render — after that the state it had is CLEAN, and keeping it puts the target back
+     * in exactly the #104 hole. Failing at execute time must make it dirty again regardless of
+     * what it was before.
+     */
+    @Test
+    fun alreadyCleanTargetThatFailsBecomesDirtyAgain() = runBlocking {
+        val (_, second) = renderUntilACleanTargetFails()
+
+        assertEquals(FAILURE, second.status, "Second render must fail. Result: $second")
+        val targets = service.getInfo(Unit).targets.associate { it.name to it.state }
+        assertEquals(
+            CLEAN,
+            targets["bad"],
+            "The target that built on the second render must be clean. Targets: $targets"
+        )
+        assertEquals(
+            NEEDS_EXEC,
+            targets["other"],
+            "A target that failed at execute time must go dirty again even though it had " +
+                "already built once and was recorded CLEAN. Targets: $targets"
+        )
+    }
+
+    /**
+     * The end-to-end half of the same case: once a previously-clean target has failed, a
+     * re-request must re-enter `render()` rather than re-broadcast the stale failure.
+     *
+     * As above, nothing about the konstruction changes between the failing render and the
+     * retry — no edit, no recompile — so SUCCESS is only reachable by really rendering again.
+     */
+    @Test
+    fun reRequestRetriesATargetThatFailedAfterAlreadyBuilding() = runBlocking {
+        val (otherMarker, second) = renderUntilACleanTargetFails()
+        assertEquals(FAILURE, second.status, "Second render must fail. Result: $second")
+
+        otherMarker.delete()
+
+        val third = service.konstruct("other")
+        assertEquals(
+            SUCCESS,
+            third.status,
+            "A target that failed after already building must still be retriable — a FAILURE " +
+                "here is the stale result being re-broadcast because render() was skipped. " +
+                "Result: $third"
+        )
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).targets.single { it.name == "other" }.state,
+            "The retried target must end up clean"
+        )
+    }
+
+    /**
+     * Drives the two renders both of the tests above need: a first one that leaves `other`
+     * CLEAN and `bad` dirty, then a second (reached through `bad`, with the failures swapped
+     * out of band) in which the already-clean `other` fails at execute time.
+     *
+     * Returns `other`'s marker file — deleting it un-breaks the target — and the second
+     * render's result.
+     */
+    private suspend fun renderUntilACleanTargetFails(): Pair<File, TaskResult> {
+        val badMarker = File(env.tempDir, "break-bad")
+        val otherMarker = File(env.tempDir, "break-other")
+        service.set(
+            """
+            val bad by primitive {
+               if (java.io.File("${badMarker.absolutePath}").exists()) {
+                   throw RuntimeException("bad-boom")
+               }
+               cube {
+                   dimensions = xyz(1.0, 1.0, 1.0)
+               }
+            }
+            val other by primitive {
+               if (java.io.File("${otherMarker.absolutePath}").exists()) {
+                   throw RuntimeException("other-boom")
+               }
+               cube {
+                   dimensions = xyz(2.0, 2.0, 2.0)
+               }
+            }
+            export("bad")
+            export("other")
+            """.trimIndent()
+        )
+        assertEquals(SUCCESS, service.compile(Unit).status, "The script must compile")
+
+        badMarker.writeText("break")
+        val first = service.konstruct("bad")
+        assertEquals(FAILURE, first.status, "First render must fail. Result: $first")
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).targets.single { it.name == "other" }.state,
+            "Setup expects 'other' to have built and be clean before it starts failing"
+        )
+
+        // Swap which target is broken. No edit and no recompile, so the only thing that can
+        // change 'other' from clean to failed is the render itself.
+        badMarker.delete()
+        otherMarker.writeText("break")
+
+        return otherMarker to service.konstruct("bad")
+    }
+
+    /**
+     * The end-to-end half: a re-request on a failed target must actually re-enter `render()`.
+     *
+     * The script fails until a marker file appears, and nothing else about the konstruction
+     * changes between the two requests — no edit, no recompile. So the second request can only
+     * report SUCCESS if it really ran the render again; if the guard skips it, the stale
+     * FAILURE comes back instead. That silent skip is the failure mode, which is why this
+     * asserts the retry rather than just the dirty flag.
+     */
+    @Test
+    fun reRequestOfAFailedTargetRunsTheRenderAgain() = runBlocking {
+        val marker = File(env.tempDir, "let-it-build")
+        service.set(
+            """
+            val flaky by primitive {
+               if (!java.io.File("${marker.absolutePath}").exists()) {
+                   throw RuntimeException("boom-104")
+               }
+               cube {
+                   dimensions = xyz(1.0, 1.0, 1.0)
+               }
+            }
+            export("flaky")
+            """.trimIndent()
+        )
+        assertEquals(SUCCESS, service.compile(Unit).status, "The script must compile")
+
+        val first = service.konstruct("flaky")
+        assertEquals(FAILURE, first.status, "First render must fail. Result: $first")
+        assertNull(service.konstructed("flaky"), "A failed render must leave no model")
+
+        marker.writeText("go")
+
+        val second = service.konstruct("flaky")
+        assertEquals(
+            SUCCESS,
+            second.status,
+            "Re-requesting a failed target must re-run the render — a FAILURE here is the " +
+                "stale result being re-broadcast because render() was skipped. Result: $second"
+        )
+        assertNotNull(service.konstructed("flaky"), "The retry must produce a model")
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).targets.single { it.name == "flaky" }.state,
+            "The retried target must end up clean"
+        )
+    }
+}

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/SubprocessFailureTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/integration/SubprocessFailureTest.kt
@@ -307,7 +307,7 @@ class SubprocessFailureTest {
         paths.renderResultFile.outputStream().use { out ->
             cfg.json.encodeToStream(result, out)
         }
-        return executed
+        return executed.allTargets
     }
 
     /** Poll a non-blocking check of the coroutine Mutex until it is free. */

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecuteTaskTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecuteTaskTest.kt
@@ -55,7 +55,7 @@ class ExecuteTaskTest {
     }
 
     /**
-     * Regression test for #81.
+     * Regression test for #81 and #104.
      *
      * A multi-target render where one export fails at EXECUTE time (compiles fine, throws while
      * building/rendering) while the subprocess stays alive and another export succeeds. The
@@ -65,8 +65,11 @@ class ExecuteTaskTest {
      *       failure and the whole render reported SUCCESS (the failed target got marked CLEAN and
      *       never retried).
      *   (b) the fetched error trace was discarded, so `messages` was always empty.
+     *   (c) the reported target list was the *attempted* one, so the caller marked the failed
+     *       target CLEAN and never retried it (#104).
      *
-     * With the fix the render must report FAILURE and surface the error trace.
+     * With the fix the render must report FAILURE, surface the error trace, and report only
+     * the target that actually built.
      */
     @Test
     fun `multi-target render fails when one target fails at execute time`() {
@@ -93,6 +96,13 @@ class ExecuteTaskTest {
         assertTrue(
             result.messages.isNotEmpty(),
             "The execute-phase error trace must be surfaced in messages. Result: $result"
+        )
+        assertEquals(
+            listOf("good"),
+            result.taskArguments,
+            "Only targets that actually built may be reported (#104) — reporting the " +
+                "attempted list marks the failed target CLEAN, so it is never retried. " +
+                "Result: $result"
         )
     }
 

--- a/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructionServiceTypes.kt
+++ b/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructionServiceTypes.kt
@@ -39,6 +39,11 @@ data class TaskMessage(
 
 @Serializable
 data class TaskResult(
+    /**
+     * The targets this result covers: for a render, the targets that actually BUILT — a
+     * target that failed at execute time is absent, which is what keeps it dirty and
+     * retriable. Empty for a compile, which is not per-target.
+     */
     val taskArguments: List<String> = emptyList(),
     val status: TaskStatus,
     val messages: List<TaskMessage> = emptyList()


### PR DESCRIPTION
Fixes #104
Fixes #122

Re-land of PR #113 (`332c472`), which was reverted in PR #119 (`5ec8579`) because it made `main`
intermittently red. Two commits, and the split is the point:

| commit | what |
| --- | --- |
| `fix(info): stop a slow persist from resurrecting stale dirty state` | the prerequisite — a pre-existing lost-update race that has nothing to do with #104, filed as #122 |
| `fix(render): keep a failed target dirty so re-running retries it` | #113 restored **verbatim** |

## The re-land itself is unmodified

The second commit is `332c472` restored by `git revert 5ec8579`, verified diff-identical by
comparing its `+`/`-` lines against `git diff 332c472^ 332c472` — same 7 files, same
405 insertions / 25 deletions. The only merge resolution was the `hasRenderResult()` declaration
that PR #121 added next to `render()` in the `KonstructionController` interface; the changed line
(`render()`'s return type) is byte-identical to #113's.

Its three-way dirty-state decision — built → CLEAN, attempted-and-failed → NEEDS_EXEC, not
attempted → unchanged — is untouched, as reviewed twice on the original PR.

## Why the same code is expected to behave differently now

The working hypothesis going in was that PR #121 (`a2d73a3`) had already removed the cause: it
stopped `konstruct()` from reading `result.json` unconditionally, which is what threw
`FileNotFoundException` when the tests ran. **That hypothesis was wrong, and the re-land still
failed** — on the very first full-suite run, unloaded:

```
FailedRenderRetryTest.reRequestRetriesATargetThatFailedAfterAlreadyBuilding
java.util.NoSuchElementException: Collection contains no element matching the predicate.
```

#121 turned the crash into the honest `Nothing was built: this konstruction has no render yet.`
FAILURE, which the test's `assertEquals(FAILURE, first.status)` accepts — so the run now walks one
line further before dying on an empty target list. Same defect, new mask.

### What is actually happening (#122)

Instrumenting `konstruct()` and reproducing under four CPU spinners:

```
DBG104 konstruct req=[bad] info=KonstructionInfo(..., dirtyState=NEEDS_COMPILE, targets=[])
DBG104 first=TaskResult(taskArguments=[], status=FAILURE,
        messages=[Nothing was built: this konstruction has no render yet. Compile it first.])
DBG104 info=KonstructionInfo(..., dirtyState=NEEDS_EXEC, targets=[])
DBG104 compileResult={"status":"SUCCESS"}
```

`compile()` had returned SUCCESS and published `NEEDS_EXEC`. `konstruct()` then read
`NEEDS_COMPILE`, failed the dirty-state guard and **skipped `render()`**. Immediately afterwards
the same field read `NEEDS_EXEC` again.

`NEEDS_EXEC → NEEDS_COMPILE → NEEDS_EXEC` with no intervening `set()` has one possible source.
`KonstructionControllerImpl.info`'s setter published the value synchronously and then ended its
async persist with `infoImpl = value` — *the value that job captured*:

```kotlin
infoImpl = value                                   // published here
GlobalScope.launch(saveContext + callSign) {
    runCatching { contentFileLock.withLock { writeInfo(...) } }...
    // Always set one more time after write to settle out any race conditions.
    infoImpl = value                               // ← resurrects it
}
```

`compile()` holds `contentFileLock` for the whole kotlinc run and the persist needs the same lock,
so the job launched by the preceding `set()` was still queued behind the compile when `compile()`
published `NEEDS_EXEC` — and then overwrote it with `NEEDS_COMPILE`. `infoImpl` has exactly two
writers (`ensureLoaded()`, which returns early once initialised, and this setter), so nothing else
can produce that sequence.

The line is redundant as well as wrong — the value is already published before the launch — so it
just goes. File writes stay correctly ordered: the jobs queue on one thread in setter order.

This is a **production** bug, not a test artefact: any user whose `compile()` is slow enough can
hit build-does-nothing, reported as a render that never ran.

### It also settles the open question on #104

The previous comment there recorded "class alone passes 5/5, full suite fails 2 of 3" and named
cross-test interference as the live hypothesis. **Disproved.** No state crosses between tests; the
window is "the single-threaded save dispatcher hasn't been scheduled yet", which widens with load
and with how much else the JVM is doing. That is also the exact mechanism behind the original #113
red — same skipped render, and pre-#121 `konstruct()` read `result.json` on that path.

## Coverage

`KonstructionControllerConcurrencyTest.aQueuedPersistDoesNotResurrectOlderInfo` drains the save
dispatcher by hand, so the interleaving is exact rather than load-dependent. Red-first verified: with
the offending line restored it fails with

```
A persist must never publish the info it captured over a newer one. Saw: [NEEDS_COMPILE, NEEDS_EXEC]
```

## Verification

`spotlessCheck :backend:jvmTest :protocol:jvmTest -Dintegration=true`, test XML deleted before each
run, on this exact tree:

| run | CPU load | result |
| --- | --- | --- |
| 1 | none | 172 tests, 0 failures, 0 errors, 6 skipped |
| 2 | none | 172 tests, 0 failures, 0 errors, 6 skipped |
| 3 | 4 spinners | 172 tests, 0 failures, 0 errors, 6 skipped |
| 4 | 4 spinners | 172 tests, 0 failures, 0 errors, 6 skipped |
| 5 | 4 spinners | 172 tests, 0 failures, 0 errors, 6 skipped |
| 6 | 4 spinners | 172 tests, 0 failures, 0 errors, 6 skipped |

6/6 green, four of them loaded, each ~11m with `:backend:jvmTest` and `:protocol:jvmTest` actually
executing (not UP-TO-DATE) and all 34 result XMLs freshly written. For contrast, the same protocol
on the re-land **without** the #122 fix failed 1/1 unloaded and 1 of 2 loaded.

The 6 skips are the ordinary no-kotlin-lsp-binary path and the 4
`This build of intellij-server has expired` lines are the deliberate fake engine in
`KotlinLspProcessExpiredEngineTest` (1 + the 3-spawn cap), both unchanged from `main`.

## Not in scope

Issues #115, #116 and #117 live in the same function and are deliberately sequenced after this. No
third `TaskStatus` state — the owner ruled all-or-nothing.
