### PR TITLE
fix(backend): drain exec pipes before waiting so a noisy kotlinc can't deadlock (#125)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/CompileTask.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/CompileTask.kt
@@ -30,7 +30,6 @@ import com.monkopedia.konstructor.common.TaskResult
 import com.monkopedia.konstructor.common.TaskStatus.FAILURE
 import com.monkopedia.konstructor.common.TaskStatus.SUCCESS
 import com.monkopedia.konstructor.tasks.ExecUtil.executeAndWait
-import java.io.BufferedReader
 import java.io.File
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -83,8 +82,8 @@ class CompileTask(private val config: Config, private val input: File, private v
         private val headerLines = KcsgScript.HEADER.split("\n").size
         private val footerLines = KcsgScript.FOOTER.split("\n").size
 
-        fun parseErrors(stdOut: BufferedReader, isError: Boolean = false): List<TaskMessage> =
-            stdOut.lineSequence().onEach {
+        fun parseErrors(output: String, isError: Boolean = false): List<TaskMessage> =
+            output.lineSequence().onEach {
                 if (isError) {
                     hauler.error(it)
                 } else {

--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecUtil.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/tasks/ExecUtil.kt
@@ -27,7 +27,10 @@ import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.sockets.asConnection
 import java.io.BufferedReader
 import java.io.IOException
-import java.io.InputStreamReader
+import java.io.InputStream
+import java.util.concurrent.Callable
+import java.util.concurrent.FutureTask
+import kotlin.concurrent.thread
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -44,11 +47,7 @@ object ExecUtil {
     @OptIn(DelicateCoroutinesApi::class)
     private val hauler by lazy { hauler().asAsync(GlobalScope) }
 
-    data class ExecResult(
-        val stdOut: BufferedReader,
-        val stdErr: BufferedReader,
-        val returnCode: Int
-    )
+    data class ExecResult(val stdOut: String, val stdErr: String, val returnCode: Int)
 
     fun executeAndWait(command: String): ExecResult {
         val rt = Runtime.getRuntime()
@@ -59,14 +58,21 @@ object ExecUtil {
             command
         )
         val proc = rt.exec(commands)
-        return ExecResult(
-            BufferedReader(InputStreamReader(proc.inputStream)),
-            BufferedReader(InputStreamReader(proc.errorStream)),
-            proc.waitFor()
-        ).also {
+        // Both pipes have to be drained while the child is still running. Once either one
+        // fills the OS pipe buffer (65536 bytes on Linux) the child blocks in write() and
+        // never exits, so waiting first deadlocks for anything but a quiet command
+        // (konstructor#125). ExecProcess below pumps its stderr for the same reason.
+        val stdOut = proc.inputStream.drainAsync("stdout")
+        val stdErr = proc.errorStream.drainAsync("stderr")
+        return ExecResult(stdOut.get(), stdErr.get(), proc.waitFor()).also {
             hauler.debug("Done executing: $command (${it.returnCode})")
         }
     }
+
+    private fun InputStream.drainAsync(name: String): FutureTask<String> =
+        FutureTask(Callable { bufferedReader().use(BufferedReader::readText) }).also { drain ->
+            thread(isDaemon = true, name = "exec-$name", block = drain::run)
+        }
 
     class ExecProcess(private val proc: Process) {
         private val parentJob = SupervisorJob()

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/CompileTaskParseErrorsTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/CompileTaskParseErrorsTest.kt
@@ -28,15 +28,15 @@ class CompileTaskParseErrorsTest {
 
     @Test
     fun testParseEmptyOutput() {
-        val reader = "".reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = ""
+        val result = CompileTask.parseErrors(output)
         assertTrue(result.isEmpty())
     }
 
     @Test
     fun testParseErrorPrefixed() {
-        val reader = "error: something went wrong".reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = "error: something went wrong"
+        val result = CompileTask.parseErrors(output)
         assertEquals(1, result.size)
         assertEquals("error: something went wrong", result[0].message)
         assertEquals(ERROR, result[0].importance)
@@ -44,8 +44,8 @@ class CompileTaskParseErrorsTest {
 
     @Test
     fun testParseWarningPrefixed() {
-        val reader = "warning: deprecated".reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = "warning: deprecated"
+        val result = CompileTask.parseErrors(output)
         assertEquals(1, result.size)
         assertEquals("warning: deprecated", result[0].message)
         assertEquals(WARNING, result[0].importance)
@@ -54,8 +54,8 @@ class CompileTaskParseErrorsTest {
     @Test
     fun testParseRegexError() {
         val line = headerLines + 5
-        val reader = "file.kt:$line:5: some error message".reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = "file.kt:$line:5: some error message"
+        val result = CompileTask.parseErrors(output)
         assertEquals(1, result.size)
         assertEquals("some error message", result[0].message)
         assertEquals(5, result[0].line)
@@ -66,8 +66,8 @@ class CompileTaskParseErrorsTest {
     @Test
     fun testParseRegexWarning() {
         val line = headerLines + 3
-        val reader = "file.kt:$line:10: warning: something".reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = "file.kt:$line:10: warning: something"
+        val result = CompileTask.parseErrors(output)
         assertEquals(1, result.size)
         assertEquals("warning: something", result[0].message)
         assertEquals(WARNING, result[0].importance)
@@ -76,8 +76,8 @@ class CompileTaskParseErrorsTest {
     @Test
     fun testParseErrorInHeaderRegion() {
         val line = headerLines - 1
-        val reader = "file.kt:$line:3: bad syntax".reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = "file.kt:$line:3: bad syntax"
+        val result = CompileTask.parseErrors(output)
         assertEquals(1, result.size)
         assertEquals("Internal error: bad syntax", result[0].message)
         assertEquals(0, result[0].line)
@@ -92,8 +92,8 @@ class CompileTaskParseErrorsTest {
             warning: global warning
             file.kt:$errorLine:2: actual error
         """.trimIndent()
-        val reader = input.reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = input
+        val result = CompileTask.parseErrors(output)
         assertEquals(3, result.size)
         assertEquals(ERROR, result[0].importance)
         assertEquals(WARNING, result[1].importance)
@@ -107,8 +107,8 @@ class CompileTaskParseErrorsTest {
             another line
             Compilation completed
         """.trimIndent()
-        val reader = input.reader().buffered()
-        val result = CompileTask.parseErrors(reader)
+        val output = input
+        val result = CompileTask.parseErrors(output)
         assertTrue(result.isEmpty())
     }
 }

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/CompileTaskTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/CompileTaskTest.kt
@@ -77,7 +77,7 @@ class CompileTaskTest {
                 TaskMessage("error: unresolved reference: classpath", 9, 9),
 
             ),
-            CompileTask.parseErrors(testOutput.byteInputStream().bufferedReader())
+            CompileTask.parseErrors(testOutput)
         )
     }
 
@@ -88,7 +88,7 @@ class CompileTaskTest {
         """.trimIndent()
         assertEquals(
             listOf(TaskMessage("error: source entry is not a Kotlin file: gradle.properties")),
-            CompileTask.parseErrors(testOutput.byteInputStream().bufferedReader())
+            CompileTask.parseErrors(testOutput)
         )
     }
 

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecUtilPipeBufferTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/tasks/ExecUtilPipeBufferTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.tasks
+
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * [ExecUtil.executeAndWait] used to call `waitFor()` with the child's stdout and stderr
+ * pipes undrained, so any command emitting more than the OS pipe buffer (65536 bytes on
+ * Linux) blocked in `write()` forever and the call never returned (konstructor#125).
+ *
+ * The volumes here straddle that buffer: [BELOW_PIPE_BUFFER] fits and returned even
+ * before the fix, [ABOVE_PIPE_BUFFER] does not. They are deliberately small — the point
+ * is crossing the threshold, not stressing memory — and none of the output is ever
+ * printed, only measured.
+ */
+class ExecUtilPipeBufferTest {
+
+    @Test
+    fun testOutputBelowPipeBufferIsReturned() {
+        val result = executeWithin(TIMEOUT_MS, emit(BELOW_PIPE_BUFFER, toStdErr = false))
+        assertEquals(BELOW_PIPE_BUFFER, result.stdOut.length)
+        assertEquals("", result.stdErr)
+        assertEquals(0, result.returnCode)
+    }
+
+    @Test
+    fun testOutputAbovePipeBufferIsReturned() {
+        val result = executeWithin(TIMEOUT_MS, emit(ABOVE_PIPE_BUFFER, toStdErr = false))
+        assertEquals(ABOVE_PIPE_BUFFER, result.stdOut.length)
+        assertEquals("", result.stdErr)
+        assertEquals(0, result.returnCode)
+    }
+
+    @Test
+    fun testErrorOutputAbovePipeBufferIsReturned() {
+        val result = executeWithin(TIMEOUT_MS, emit(ABOVE_PIPE_BUFFER, toStdErr = true))
+        assertEquals("", result.stdOut)
+        assertEquals(ABOVE_PIPE_BUFFER, result.stdErr.length)
+        assertEquals(0, result.returnCode)
+    }
+
+    @Test
+    fun testBothStreamsAbovePipeBufferStayDistinct() {
+        val command = "${emit(ABOVE_PIPE_BUFFER, toStdErr = false)}; " +
+            "${emit(ABOVE_PIPE_BUFFER, toStdErr = true)}; exit 3"
+        val result = executeWithin(TIMEOUT_MS, command)
+        assertEquals(ABOVE_PIPE_BUFFER, result.stdOut.length)
+        assertEquals(ABOVE_PIPE_BUFFER, result.stdErr.length)
+        assertEquals(3, result.returnCode)
+    }
+
+    companion object {
+        private const val BELOW_PIPE_BUFFER = 65000
+        private const val ABOVE_PIPE_BUFFER = 66000
+        private const val TIMEOUT_MS = 30_000L
+
+        /** A command writing exactly [bytes] printable characters to one stream. */
+        private fun emit(bytes: Int, toStdErr: Boolean) =
+            "head -c $bytes /dev/zero | tr '\\0' 'x'" + if (toStdErr) " 1>&2" else ""
+
+        /**
+         * Runs [command] on a throwaway thread so a deadlocked
+         * [ExecUtil.executeAndWait] fails this test instead of hanging the whole suite.
+         */
+        private fun executeWithin(timeoutMs: Long, command: String): ExecUtil.ExecResult {
+            var result: ExecUtil.ExecResult? = null
+            var failure: Throwable? = null
+            thread(isDaemon = true, name = "exec-under-test") {
+                try {
+                    result = ExecUtil.executeAndWait(command)
+                } catch (t: Throwable) {
+                    failure = t
+                }
+            }.join(timeoutMs)
+            failure?.let { throw it }
+            return result
+                ?: fail("executeAndWait did not return within ${timeoutMs}ms for: $command")
+        }
+    }
+}


### PR DESCRIPTION
`ExecUtil.executeAndWait` constructed two `BufferedReader`s over the child's stdout and stderr and then called `waitFor()`. Wrapping a stream reads nothing, so **neither pipe was drained while the process ran**: once the child wrote past the OS pipe buffer (65536 bytes on Linux) it blocked in `write()` and `waitFor()` never returned. The sole caller is the user-script compile path, where the volume is bounded only by how many warnings the user's script provokes out of `kotlinc`.

## The change

- `executeAndWait` drains both streams on dedicated threads and waits afterwards — the same shape `ExecProcess`, in the same file, already uses for its stderr pump.
- `ExecResult` carries the text that was read rather than two live readers over a finished process, and `CompileTask.parseErrors` now takes that text. Stdout and stderr stay distinct, so the `isError = true` tagging is unchanged.

Kept deliberately small: no `ProcessBuilder`/lifecycle change, no temp files, no merged stream.

## Red/green — both measured

Regression test `ExecUtilPipeBufferTest` straddles the buffer at 65000 / 66000 bytes on stdout, on stderr, and on both at once, and runs the call on a throwaway thread with a 30s watchdog so a deadlock **fails** the test instead of hanging the suite. Output is measured, never printed, and tops out at ~200 KB total, so nothing accumulates the way the `copyTo(System.err)` writer in PR `#105` did.

**RED** — surgical mutation only (`waitFor()` moved back ahead of the two drains, API untouched, so the test still compiles):

```
./gradlew :backend:jvmTest --tests "*ExecUtilPipeBufferTest*"
4 tests completed, 3 failed          BUILD FAILED in 3m 37s (53 tasks executed)
  testOutputAbovePipeBufferIsReturned        FAILED  "did not return within 30000ms"
  testErrorOutputAbovePipeBufferIsReturned   FAILED  "did not return within 30000ms"
  testBothStreamsAbovePipeBufferStayDistinct FAILED  "did not return within 30000ms"
  testOutputBelowPipeBufferIsReturned        PASSED  <- 65000 bytes fits the buffer
```

The one passing case is the control: the probe can report the other answer, and the split lands exactly where the issue said it would.

**GREEN** — with the fix in place, re-run on the exact committed tree after deleting every result XML first:

```
./gradlew :backend:jvmTest      BUILD SUCCESSFUL in 10m 16s
159 tests, 0 failures, 0 errors, 19 skipped   (33 fresh result XMLs; the 19 skips are the
                                               integration tests that need -Dintegration=true)
  all four ExecUtilPipeBufferTest cases pass, each in single-digit ms
./gradlew spotlessCheck         BUILD SUCCESSFUL (20 tasks executed, 0 up-to-date)
```

Everything above ran under the fleet build slot; no run reported exit 75.

Fixes #125
