### PR TITLE
Cache KonstructionControllers strongly so their locks can't be swapped

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructorManager.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructorManager.kt
@@ -16,10 +16,27 @@
 package com.monkopedia.konstructor
 
 import com.monkopedia.konstructor.common.Konstruction
-import java.util.WeakHashMap
 
 class KonstructorManager private constructor(private val config: Config) {
-    private val controllers = WeakHashMap<Pair<String, String>, KonstructionController>()
+    // Strong map, entries never evicted. This used to be a WeakHashMap, which holds its
+    // KEYS weakly -- and the key here is `workspaceId to id`, a Pair allocated fresh on
+    // every call that nothing outside the map ever references. Every entry was therefore
+    // weakly reachable the instant it was inserted, so any GC could drop it even while the
+    // controller itself was strongly held by KonstructionServiceImpl. The next lookup then
+    // built a second KonstructionControllerImpl with its own contentFileLock/scriptLock,
+    // and the script path and service path locked different Mutexes for the same
+    // konstruction -- silently, permanently, from the first GC onward (#126).
+    //
+    // Controller identity is load-bearing precisely because those Mutexes are per-instance
+    // fields, so this cache must not evict: adding an eviction policy here reintroduces the
+    // same defect. Nothing is scoped to a controller's lifecycle (there is no close/shutdown
+    // on KonstructionController), so retaining one per konstruction for the process lifetime
+    // is the accepted cost. Matches the strong per-Config caches in PathController and
+    // ScriptManager.
+    //
+    // Mutation is confined to controllerFor below, entirely under `synchronized(controllers)`,
+    // which is what makes the get-construct-put sequence atomic.
+    private val controllers = mutableMapOf<Pair<String, String>, KonstructionController>()
 
     fun controllerFor(konstruction: Konstruction): KonstructionController =
         controllerFor(konstruction.workspaceId, konstruction.id)

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructorManagerTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructorManagerTest.kt
@@ -22,9 +22,13 @@ import com.monkopedia.konstructor.common.Konstruction
 import com.monkopedia.konstructor.common.KonstructionInfo
 import com.monkopedia.konstructor.testutil.TestEnvironment
 import java.io.File
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
+import kotlin.test.fail
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.encodeToStream
 import org.junit.After
@@ -67,6 +71,88 @@ class KonstructorManagerTest {
         assertSame(controller1, controller2)
     }
 
+    /**
+     * The controller cache must survive garbage collection.
+     *
+     * `contentFileLock` and `scriptLock` are per-instance fields of
+     * `KonstructionControllerImpl`, and callers reach them *through* this cache
+     * (`ScriptManager`, `ScriptHostImpl`). If the cache entry can disappear, two callers
+     * working on the same konstruction get two different `Mutex` instances and the mutual
+     * exclusion silently evaporates.
+     *
+     * Note `controller1` is held strongly for the whole test: the point is that the
+     * *entry* must survive, not merely the value. A weak-**key** map loses the entry even
+     * while the value is strongly reachable, because nothing outside the map ever holds
+     * the freshly allocated key.
+     *
+     * [forceWeakKeyCollection] fails the test if the JVM never actually collects, so a
+     * pass here cannot mean "the GC simply never ran" — the flaw that made
+     * [testSameIdReturnsSameController] unable to fail.
+     */
+    @Test
+    fun testSameControllerAfterGarbageCollection() {
+        env.createWorkspaceDir("ws1", "Workspace 1")
+        createKonstructionInfo("ws1", "k1", "test-k")
+        val controller1 = manager.controllerFor("ws1", "k1")
+
+        forceWeakKeyCollection()
+
+        val controller2 = manager.controllerFor("ws1", "k1")
+        assertSame(
+            controller1,
+            controller2,
+            "Controller cache dropped its entry across a GC; per-konstruction locks " +
+                "(contentFileLock/scriptLock) are per-instance, so callers would now be " +
+                "locking different Mutex instances for the same konstruction."
+        )
+        assertSame(
+            controller1.scriptLock,
+            controller2.scriptLock,
+            "scriptLock identity is the invariant that actually matters."
+        )
+    }
+
+    /**
+     * Positive control for the GC assertion above.
+     *
+     * Builds a canary entry with exactly the reachability shape of the cache under test —
+     * a weakly held key that nothing outside the map references — and drives GC until it
+     * is observably cleared. Returning normally means weak keys *were* collected in this
+     * JVM at this moment; if that never happens within the budget the test fails rather
+     * than proceeding to an assertion that could only pass vacuously.
+     */
+    private fun forceWeakKeyCollection() {
+        val canaryMap = WeakHashMap<Any, Any>()
+        val canaryRef = allocateCanary(canaryMap)
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(GC_BUDGET_SECONDS)
+        var attempts = 0
+        while (System.nanoTime() < deadline) {
+            attempts++
+            System.gc()
+            if (canaryRef.get() == null && canaryMap.isEmpty()) return
+            // Allocation pressure: System.gc() is advisory, so give the collector a
+            // reason as well as a request.
+            @Suppress("UNUSED_VARIABLE")
+            val ballast = ByteArray(BALLAST_BYTES)
+            Thread.sleep(GC_POLL_MILLIS)
+        }
+        fail(
+            "GC never cleared a weakly-keyed canary entry after $attempts attempts in " +
+                "${GC_BUDGET_SECONDS}s; the identity assertion would have been vacuous."
+        )
+    }
+
+    /**
+     * Allocated in its own frame so the only reference to the canary dies with that frame
+     * (a local in the calling method can otherwise stay live in a stack slot). The value
+     * is a constant String, never anything that refers back to the key.
+     */
+    private fun allocateCanary(map: WeakHashMap<Any, Any>): WeakReference<Any> {
+        val canary = Any()
+        map[canary] = CANARY_VALUE
+        return WeakReference(canary)
+    }
+
     @Test
     fun testDifferentIdReturnsDifferentController() {
         env.createWorkspaceDir("ws1", "Workspace 1")
@@ -75,5 +161,12 @@ class KonstructorManagerTest {
         val controller1 = manager.controllerFor("ws1", "k1")
         val controller2 = manager.controllerFor("ws1", "k2")
         assertNotSame(controller1, controller2)
+    }
+
+    companion object {
+        private const val CANARY_VALUE = "canary"
+        private const val GC_BUDGET_SECONDS = 30L
+        private const val GC_POLL_MILLIS = 20L
+        private const val BALLAST_BYTES = 4 * 1024 * 1024
     }
 }


### PR DESCRIPTION
## What

`KonstructorManager.controllers` was a `java.util.WeakHashMap` keyed by `workspaceId to id`.

`WeakHashMap` holds its **keys** weakly. That key is a `Pair` allocated fresh on every call, and nothing outside the map ever holds it — the value keeps the two `String`s but never the `Pair`. So every entry was weakly reachable the instant it was inserted, and any GC could clear it.

Controller *identity* is load-bearing, because the mutual-exclusion primitives are per-instance fields of `KonstructionControllerImpl` (`contentFileLock`, `scriptLock`) and both are reached **through this cache** (`hostservices/ScriptManager.kt:68`, `hostservices/ScriptHostImpl.kt:58/72/89`). Once the entry is dropped, the next lookup constructs a second controller with its own Mutexes, and two callers working on the same konstruction lock different objects — no exception, no log.

It is also wider than "a GC landing between two adjacent statements". `KonstructionServiceImpl.kt:79` holds its controller in a field for the service's lifetime. That keeps the *value* alive but not the *entry*, because the entry's key is what is weak. From the first GC after the service is constructed, the script path and the service path use different mutexes for that konstruction, permanently.

## Change

`controllers` becomes a strong `mutableMapOf`, matching the sibling per-`Config` caches in `PathController.kt` and `hostservices/ScriptManager.kt`.

Entries are never evicted, deliberately. Because the locks are per-instance fields, **adding an eviction policy to this cache reintroduces exactly this defect** — there is a comment on the field saying so. The cost is one retained controller per konstruction ever touched, which is accepted: nothing in the codebase is scoped to a controller's lifecycle (`KonstructionController` has no `close`/`shutdown` at all, so there is nothing that release would trigger).

**No `ConcurrentHashMap` needed, and I checked rather than assumed.** `controllers` is private and its only access is inside `controllerFor`, wholly within `synchronized(controllers)` — the get / construct / put sequence is already atomic against other callers. A bare `getOrPut` outside a lock would indeed have reintroduced a narrower version of the same "two different Mutexes" bug; it is not outside a lock. The `Pair` key is fine under a strong map: `kotlin.Pair` is a data class over two `String`s, and `testSameIdReturnsSameController` exercises exactly that (two calls allocate two distinct-but-equal `Pair`s and must hit the same entry).

## Test — and the RED it was proved against

The existing invariant test could not fail:

```kotlin
val controller1 = manager.controllerFor("ws1", "k1")
val controller2 = manager.controllerFor("ws1", "k1")
assertSame(controller1, controller2)
```

Two adjacent statements, no allocation pressure, so no GC — green for reasons unrelated to the code being correct. That inert gate is why the defect survived.

The replacement, `testSameControllerAfterGarbageCollection`:

- holds `controller1` strongly for the whole test — the point is that the **entry** must survive, not merely the value;
- calls `forceWeakKeyCollection()`, which builds a canary entry with the *same* reachability shape (a weakly held key nothing else references, allocated in its own frame so no stack slot keeps it live) and drives `System.gc()` plus allocation pressure until a `WeakReference` to it is observably cleared **and** the canary `WeakHashMap` has expunged it;
- **fails the test outright** if that never happens inside a 30s budget. `System.gc()` is advisory, so the only pass path through the helper is one where collection was *confirmed*. A green here cannot mean "the GC simply never ran";
- then asserts both controller identity and `scriptLock` identity.

**Measured, full suite, no `--tests` filter, XML deleted before each run:**

| | tests | failed | errors | skipped |
|---|---|---|---|---|
| RED (`WeakHashMap`, new test only) | 160 | **1** | 0 | 19 |
| GREEN (strong map) | 160 | 0 | 0 | 19 |

RED failure, verbatim:

```
Controller cache dropped its entry across a GC; per-konstruction locks
(contentFileLock/scriptLock) are per-instance, so callers would now be locking
different Mutex instances for the same konstruction.
expected same:<...KonstructionControllerImpl@7c211fd0> was not:<...@7004e3d>
```

Two genuinely different instances — and note the test reached that assertion, i.e. the GC positive control was satisfied rather than the helper bailing out. It reproduced on the first `System.gc()` attempt (0.055s), so this is not a slow or marginal test.

`./gradlew :backend:jvmTest spotlessCheck` → `BUILD SUCCESSFUL`, `:backend:jvmTest` executed (not `UP-TO-DATE`), spotless clean across all five modules.

## Known cost, not fixed here

`KonstructionControllerImpl` takes `saveContext = newSingleThreadContext("KonstructionController")` typed as `CoroutineContext`, so it cannot be closed, and there is no shutdown path in `KonstructionController.kt`. **That thread was already never reclaimed** — under the old weak map it leaked one per GC cycle, i.e. per re-creation. A strong map makes it one thread per konstruction instead of one per GC cycle, which is strictly better than today, but the thread is still never released and this PR does not change that. Recording it so the cost of the never-evicting cache is on the record; out of scope here.

The lock-registry alternative (hoist `contentFileLock`/`scriptLock` off the cache so identity stops mattering) was considered on the issue and priced as a wider change. Not attempted here.

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
