### PR TITLE
Close the discarded HttpClient/websocket on every reconnect attempt (#127)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,15 @@ jobs:
         # a real kotlin-lsp engine, absent on the runner); soak stays off.
         run: ./gradlew test :backend:jvmTest :protocol:jvmTest -Dintegration=true
 
+      - name: Run frontend wasmJs unit tests (Karma + headless Chrome)
+        run: |
+          export CHROME_BIN="${CHROME_BIN:-$(command -v google-chrome \
+            || command -v google-chrome-stable \
+            || command -v chromium-browser \
+            || command -v chromium)}"
+          echo "Using CHROME_BIN=$CHROME_BIN"
+          ./gradlew :frontend:wasmJsBrowserTest
+
       - name: Run e2e tests under Xvfb
         run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' ./gradlew :e2e:test -Pe2e
 

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -29,11 +29,21 @@ repositories {
 
 kotlin {
     wasmJs {
-        browser()
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
         binaries.executable()
     }
     sourceSets["commonMain"].dependencies {
         implementation(compose.components.resources)
+    }
+    sourceSets["wasmJsTest"].dependencies {
+        implementation(kotlin("test"))
+        implementation(libs.kotlinx.coroutines.test)
     }
     sourceSets["wasmJsMain"].dependencies {
         // Compose

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/ServiceHolder.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/ServiceHolder.kt
@@ -16,21 +16,66 @@
 package com.monkopedia.konstructor.frontend.viewmodel
 
 import com.monkopedia.konstructor.common.Konstructor
+import com.monkopedia.konstructor.frontend.threejs.consoleError
+import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.ktor.websocket.asWebsocketConnection
 import com.monkopedia.ksrpc.toStub
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.browser.window
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class ServiceHolder {
+/**
+ * How long to wait between keep-alive pings on an established connection.
+ */
+private const val KEEP_ALIVE_INTERVAL_MS = 10_000L
 
-    private val scope = kotlinx.coroutines.MainScope()
+/**
+ * How long to wait before starting the next connection attempt. Deliberately a
+ * flat interval — changing the retry cadence (backoff/jitter/caps) is a policy
+ * question tracked separately from the resource handling here.
+ */
+private const val RECONNECT_DELAY_MS = 3_000L
+
+/**
+ * One attempt's worth of connection state: the stub callers talk to, plus every
+ * resource that had to be allocated to produce it.
+ *
+ * [close] exists so the reconnect loop can release an attempt's resources
+ * instead of abandoning them; a [ServiceConnection] that is dropped without
+ * being closed is a leak of an [HttpClient] (which owns an engine and its own
+ * coroutine scope) and of a live websocket.
+ */
+internal interface ServiceConnection {
+    val stub: Konstructor
+
+    suspend fun close()
+}
+
+/**
+ * Establishes a [ServiceConnection]. Exists as a seam so the reconnect loop's
+ * resource handling can be observed in tests without a real websocket.
+ */
+internal fun interface ConnectionFactory {
+    suspend fun connect(): ServiceConnection
+}
+
+class ServiceHolder internal constructor(
+    private val connectionFactory: ConnectionFactory,
+    private val scope: CoroutineScope
+) {
+
+    constructor() : this(WebSocketConnectionFactory(), MainScope())
 
     private val _service = MutableStateFlow<Konstructor?>(null)
     val service: StateFlow<Konstructor?> = _service.asStateFlow()
@@ -46,32 +91,86 @@ class ServiceHolder {
 
     private suspend fun connect() {
         while (true) {
+            var connection: ServiceConnection? = null
             try {
-                val hostname = window.location.hostname
-                val port = window.location.port
-                val protocol = if (window.location.protocol == "https:") "wss" else "ws"
-                val url = "$protocol://$hostname:$port/konstructor"
-                val env = ksrpcEnvironment { }
-                val client = HttpClient { install(WebSockets) }
-                val conn = client.asWebsocketConnection(url, env)
-                val stub = conn.defaultChannel().toStub<Konstructor, String>()
+                connection = connectionFactory.connect()
+                val stub = connection.stub
                 stub.ping()
                 _service.value = stub
                 _connected.value = true
                 // Keep-alive loop
                 while (true) {
-                    delay(10_000)
+                    delay(KEEP_ALIVE_INTERVAL_MS)
                     try {
                         stub.ping()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
+                        consoleError("Konstructor keep-alive ping failed: $e")
                         break
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
+                consoleError("Konstructor connection attempt failed: $e")
                 _service.value = null
                 _connected.value = false
+            } finally {
+                // Whether the attempt failed outright or the keep-alive loop
+                // dropped out, this attempt's resources are being discarded —
+                // release them rather than abandoning them.
+                connection?.closeQuietly()
             }
-            delay(3_000)
+            delay(RECONNECT_DELAY_MS)
+        }
+    }
+
+    private suspend fun ServiceConnection.closeQuietly() {
+        try {
+            withContext(NonCancellable) {
+                close()
+            }
+        } catch (e: Throwable) {
+            consoleError("Failed to close Konstructor connection: $e")
+        }
+    }
+}
+
+/**
+ * The real factory: opens a websocket to the page's own origin.
+ */
+internal class WebSocketConnectionFactory : ConnectionFactory {
+    override suspend fun connect(): ServiceConnection {
+        val hostname = window.location.hostname
+        val port = window.location.port
+        val protocol = if (window.location.protocol == "https:") "wss" else "ws"
+        val url = "$protocol://$hostname:$port/konstructor"
+        val env = ksrpcEnvironment { }
+        val client = HttpClient { install(WebSockets) }
+        try {
+            val conn = client.asWebsocketConnection(url, env)
+            val stub = conn.defaultChannel().toStub<Konstructor, String>()
+            return WebSocketServiceConnection(client, conn, stub)
+        } catch (e: Throwable) {
+            // The client is already allocated at this point; don't strand it
+            // just because the handshake or the stub lookup blew up.
+            client.close()
+            throw e
+        }
+    }
+}
+
+private class WebSocketServiceConnection(
+    private val client: HttpClient,
+    private val connection: Connection<String>,
+    override val stub: Konstructor
+) : ServiceConnection {
+    override suspend fun close() {
+        try {
+            connection.close()
+        } finally {
+            client.close()
         }
     }
 }

--- a/frontend/src/wasmJsTest/kotlin/com/monkopedia/konstructor/frontend/viewmodel/ServiceHolderConnectionLeakTest.kt
+++ b/frontend/src/wasmJsTest/kotlin/com/monkopedia/konstructor/frontend/viewmodel/ServiceHolderConnectionLeakTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.frontend.viewmodel
+
+import com.monkopedia.hauler.Shipper
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionService
+import com.monkopedia.konstructor.common.Konstructor
+import com.monkopedia.konstructor.common.Space
+import com.monkopedia.konstructor.common.Workspace
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The reconnect loop allocates an [io.ktor.client.HttpClient] and a websocket
+ * for every attempt. Nothing about those objects is observable from outside, so
+ * these tests substitute a [ConnectionFactory] that hands out counted stand-ins
+ * and assert on the count that matters: how many connections have been
+ * allocated and never closed.
+ *
+ * The assertion that carries the weight is `live == 0`. Against the pre-fix loop
+ * (no `finally { connection?.closeQuietly() }`) `live` grows by one per attempt.
+ */
+class ServiceHolderConnectionLeakTest {
+
+    @Test
+    fun failedAttemptsDoNotAccumulateOpenConnections() = runTest {
+        // Every attempt gets as far as allocating a connection and then fails
+        // its first ping — the "backend is down" case.
+        val factory = CountingConnectionFactory(successfulPingsPerConnection = 0)
+        ServiceHolder(factory, backgroundScope)
+
+        // NB: advanceTimeBy (not advanceUntilIdle) — the holder runs in
+        // backgroundScope, and advanceUntilIdle only drains foreground work.
+        advanceTimeBy(30_001)
+        runCurrent()
+
+        // Instrument check: the loop really did retry many times.
+        assertTrue(
+            factory.created >= 10,
+            "expected the reconnect loop to have made >= 10 attempts, made ${factory.created}"
+        )
+        assertEquals(
+            factory.created,
+            factory.closed,
+            "every allocated connection should have been closed"
+        )
+        assertEquals(0, factory.live, "connections allocated and never closed")
+    }
+
+    @Test
+    fun droppedKeepAliveDoesNotAccumulateOpenConnections() = runTest {
+        // Each attempt connects successfully, then the keep-alive ping fails —
+        // the "backend restarted under us" case, where the old client is
+        // abandoned in favour of a new one.
+        val factory = CountingConnectionFactory(successfulPingsPerConnection = 1)
+        ServiceHolder(factory, backgroundScope)
+
+        advanceTimeBy(130_001)
+        runCurrent()
+
+        assertTrue(
+            factory.created >= 5,
+            "expected >= 5 connect/drop cycles, saw ${factory.created}"
+        )
+        // At most the one connection currently established is still open; every
+        // earlier cycle's connection must already have been closed.
+        assertTrue(
+            factory.live <= 1,
+            "expected <= 1 open connection, ${factory.live} of ${factory.created} " +
+                "were allocated and never closed"
+        )
+    }
+
+    @Test
+    fun cancellingTheScopeClosesTheLiveConnection() = runTest {
+        val factory = CountingConnectionFactory(successfulPingsPerConnection = Int.MAX_VALUE)
+        val scope = CoroutineScope(backgroundScope.coroutineContext + Job())
+        ServiceHolder(factory, scope)
+
+        advanceTimeBy(1)
+        assertEquals(1, factory.created)
+        assertEquals(1, factory.live, "expected one established connection")
+
+        scope.cancel()
+        advanceTimeBy(1)
+        runCurrent()
+
+        assertEquals(0, factory.live, "cancellation must not strand the open connection")
+    }
+}
+
+private class CountingConnectionFactory(private val successfulPingsPerConnection: Int) :
+    ConnectionFactory {
+    var created = 0
+        private set
+    var closed = 0
+        private set
+
+    val live: Int get() = created - closed
+
+    override suspend fun connect(): ServiceConnection {
+        created++
+        return CountingConnection(successfulPingsPerConnection) { closed++ }
+    }
+}
+
+private class CountingConnection(successfulPings: Int, private val onClose: () -> Unit) :
+    ServiceConnection {
+    private var isClosed = false
+
+    override val stub: Konstructor = FlakyKonstructor(successfulPings)
+
+    override suspend fun close() {
+        check(!isClosed) { "connection closed twice" }
+        isClosed = true
+        onClose()
+    }
+}
+
+private class FlakyKonstructor(private var remainingSuccessfulPings: Int) : Konstructor {
+    override suspend fun ping(u: Unit) {
+        if (remainingSuccessfulPings <= 0) {
+            throw IllegalStateException("connection refused")
+        }
+        if (remainingSuccessfulPings != Int.MAX_VALUE) {
+            remainingSuccessfulPings--
+        }
+    }
+
+    override suspend fun list(u: Unit): List<Space> = error("unused")
+    override suspend fun get(id: String): Workspace = error("unused")
+    override suspend fun konstruction(id: Konstruction): KonstructionService = error("unused")
+    override suspend fun create(newItem: Space): Space = error("unused")
+    override suspend fun delete(item: Space) = error("unused")
+    override suspend fun getGlobalShipper(u: Unit): Shipper = error("unused")
+}


### PR DESCRIPTION
`ServiceHolder.connect()` allocated a new `HttpClient` — which owns an engine and its own coroutine scope — plus a live websocket on **every** pass of the reconnect loop, and closed none of them.

- backend down → one leaked client every 3s for as long as the tab is open (20/min, 1200/hr);
- backend restarts → the keep-alive `ping()` throws, the loop `break`s, and the **still-open** client is abandoned in favour of a new one.

## What changed

- A `ServiceConnection` / `ConnectionFactory` seam owns one attempt's resources (`HttpClient` + ksrpc `Connection` + stub). The loop closes it in a `finally`, so an attempt that is being discarded is released rather than abandoned — whether it failed outright or its keep-alive dropped out.
- Cancellation now closes the live connection too (`withContext(NonCancellable)`) instead of stranding it.
- The real factory closes its `HttpClient` if the handshake or stub lookup throws after the client is already allocated.
- Both `catch (e: Exception)` sites bound `e` and logged **nothing** — a reconnect storm was completely invisible. Both now `consoleError` the exception and rethrow `CancellationException` explicitly, matching `threejs/ThreeJsRenderer.kt`. Previously cancellation escaped only by the accident of `delay(3_000)` sitting outside the `try`; any edit moving that delay inside would have made the loop uncancellable.
- The two timing literals are named (`KEEP_ALIVE_INTERVAL_MS`, `RECONNECT_DELAY_MS`). **Values unchanged.**

## Deliberately not in this PR

The **retry cadence**. Flat 3s, no backoff/jitter/cap is a policy question, not a leak, so it is split out as #135 (`needs-decision`) rather than folded in — as the triage note asked. Also left alone there: the loop `break`s out of keep-alive without clearing `_service`/`_connected`, so the UI keeps reporting "connected" for the retry gap. Changing that is product-visible and belongs with whatever cadence is chosen.

## Test infrastructure

`:frontend` had **no test source set at all** — the module was entirely untested. This PR adds `wasmJsTest` (Karma + headless Chrome, the same machinery `:protocol` already configures) and wires `:frontend:wasmJsBrowserTest` into CI. The CI step resolves `CHROME_BIN` from whichever chrome/chromium is on the runner.

Before writing the leak test I ran a deliberately-failing probe test through the new source set to confirm the instrument *can* go red: `2 tests completed, 1 failed`. It can.

## RED / GREEN

The leak is resource retention, which passes silently. Three tests substitute a counting `ConnectionFactory` and assert on connections **allocated and never closed**.

RED came from a surgical mutation — dropping only the `finally { connection?.closeQuietly() }` line, leaving the API the tests compile against completely intact (a `BUILD FAILED` with `tests=0` would have been a compile failure, not a red test):

| test | RED (`finally` removed) | GREEN (this PR) |
|---|---|---|
| `failedAttemptsDoNotAccumulateOpenConnections` | 11 created, **0 closed** | 11 created, 11 closed, 0 live |
| `droppedKeepAliveDoesNotAccumulateOpenConnections` | **11 of 11** allocated and never closed | ≤1 live (only the currently-established one) |
| `cancellingTheScopeClosesTheLiveConnection` | **1 stranded** | 0 stranded |

`3 tests completed, 3 failed` → `tests="3" ... failures="0"`.

Commands (result XML deleted first, tasks confirmed `executed`):

```
CHROME_BIN=/usr/bin/chromium ./gradlew :frontend:wasmJsBrowserTest
./gradlew spotlessCheck :frontend:wasmJsBrowserDistribution :frontend:wasmJsBrowserTest
```

`spotlessCheck` clean; `:frontend:wasmJsBrowserDistribution` still builds with the new source set present.

## Not verified

GitHub Actions is mid-outage, so the new CI step has **not** been observed running on a runner — only locally against `/usr/bin/chromium`. It should be watched on its first green CI run.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
