### PR TITLE
Report a failed render as RENDER_FAILED rather than CLEAN (#117)

### DIFF
--- a/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
+++ b/backend/src/jvmMain/kotlin/com/monkopedia/konstructor/KonstructionServiceImpl.kt
@@ -23,6 +23,7 @@ import com.monkopedia.konstructor.common.DirtyState
 import com.monkopedia.konstructor.common.DirtyState.CLEAN
 import com.monkopedia.konstructor.common.DirtyState.NEEDS_COMPILE
 import com.monkopedia.konstructor.common.DirtyState.NEEDS_EXEC
+import com.monkopedia.konstructor.common.DirtyState.RENDER_FAILED
 import com.monkopedia.konstructor.common.KonstructionCallbacks
 import com.monkopedia.konstructor.common.KonstructionCallbacks.CONTENT_CHANGE
 import com.monkopedia.konstructor.common.KonstructionCallbacks.DIRTY_CHANGE
@@ -270,7 +271,8 @@ class KonstructionServiceImpl(
                 info.targets.any { it.name in targets && it.state == NEEDS_EXEC }
             ) {
                 val rendered = konstructionController.render(targets)
-                val latestBuilt = konstructionController.lastRenderResult().taskArguments
+                val lastRender = konstructionController.lastRenderResult()
+                val latestBuilt = lastRender.taskArguments
                 val existingTargets = info.targets.associateBy { it.name }
                 val changedTargets = mutableListOf<KonstructionTarget>()
                 val targets = rendered.allTargets.map { target ->
@@ -296,7 +298,18 @@ class KonstructionServiceImpl(
                     } ?: KonstructionTarget(target, dirtyState).also(changedTargets::add)
                 }
                 val newInfo = info.copy(
-                    dirtyState = CLEAN,
+                    // What the render reported, not an unconditional CLEAN. `ExecuteTask`
+                    // fails the whole render when any attempted target errors, so this says
+                    // "the last build worked" / "it did not" — and a konstruction whose
+                    // render just failed no longer reads CLEAN to `ScriptHostImpl.findScript`
+                    // or to anything else treating the flag as "last build was good" (#117).
+                    //
+                    // Deliberately NOT NEEDS_EXEC: that is the frontend's auto-build trigger
+                    // (`KonstructionViewModel.onInfoChanged`), so a permanently-failing target
+                    // would loop render -> fail -> re-request. RENDER_FAILED carries the
+                    // failure without asking for a retry; the retry route is the per-target
+                    // NEEDS_EXEC above, which the second clause of the guard reads (#104).
+                    dirtyState = if (lastRender.status == SUCCESS) CLEAN else RENDER_FAILED,
                     targets = targets
                 )
                 konstructionController.info = newInfo

--- a/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionServiceDirtyStateTest.kt
+++ b/backend/src/jvmTest/kotlin/com/monkopedia/konstructor/KonstructionServiceDirtyStateTest.kt
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor
+
+import com.monkopedia.hauler.CallSign
+import com.monkopedia.konstructor.common.DirtyState.CLEAN
+import com.monkopedia.konstructor.common.DirtyState.NEEDS_EXEC
+import com.monkopedia.konstructor.common.DirtyState.RENDER_FAILED
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionInfo
+import com.monkopedia.konstructor.common.KonstructionTarget
+import com.monkopedia.konstructor.common.TaskResult
+import com.monkopedia.konstructor.common.TaskStatus
+import com.monkopedia.konstructor.logging.WarehouseWrapper
+import com.monkopedia.konstructor.testutil.TestEnvironment
+import io.ktor.utils.io.ByteReadChannel
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * The konstruction-level [KonstructionInfo.dirtyState] after a render (#117).
+ *
+ * `konstruct()` used to write `dirtyState = CLEAN` unconditionally, so a konstruction whose
+ * render had just failed reported itself clean — misleading on its own, and actively wrong for
+ * [com.monkopedia.konstructor.hostservices.ScriptHostImpl.findScript], which reads the flag as
+ * "the last build was good" to decide whether an imported konstruction needs recompiling.
+ *
+ * The render is driven through a [FakeController] rather than kotlinc plus a script
+ * subprocess: the behaviour under test lives entirely in how [KonstructionServiceImpl] turns
+ * what a render reported into dirty state, and the fake reproduces exactly the contract
+ * [com.monkopedia.konstructor.tasks.ExecuteTask] produces (built targets in
+ * [TaskResult.taskArguments], FAILURE as soon as any attempted target errors). That keeps
+ * these in the ordinary `:backend:jvmTest` run instead of behind `-Dintegration=true`.
+ *
+ * Every case asserts [FakeController.renderCalls] as well as the state. Dirty-state tests in
+ * this repo have passed vacuously before by never entering `render()` at all — the `:263`
+ * guard skips it silently — so "the render actually ran" is part of what is being asserted,
+ * not an assumption.
+ */
+class KonstructionServiceDirtyStateTest {
+
+    private lateinit var env: TestEnvironment
+    private lateinit var controller: FakeController
+    private lateinit var service: KonstructionServiceImpl
+
+    @BeforeTest
+    fun setUp() {
+        env = TestEnvironment()
+        env.createWorkspaceDir("ws1", "Test")
+        controller = FakeController(
+            config = env.config,
+            allTargets = listOf("good", "bad"),
+            attemptedTargets = listOf("good", "bad"),
+            info = KonstructionInfo(
+                Konstruction(name = "test", workspaceId = "ws1", id = "k1"),
+                // Straight out of a successful compile: the konstruction owes a render and
+                // both of its targets do too, which is what lets `konstruct()` past the guard.
+                dirtyState = NEEDS_EXEC,
+                targets = listOf(
+                    KonstructionTarget("good", NEEDS_EXEC),
+                    KonstructionTarget("bad", NEEDS_EXEC)
+                )
+            )
+        )
+        installController(env.config, "ws1", "k1", controller)
+        service = KonstructionServiceImpl(
+            config = env.config,
+            workspaceId = "ws1",
+            id = "k1",
+            warehouseWrapper = WarehouseWrapper(),
+            onClose = {}
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        env.close()
+    }
+
+    /**
+     * The defect: a render in which a target failed to build left the konstruction CLEAN.
+     */
+    @Test
+    fun failedRenderDoesNotLeaveTheKonstructionClean() = runBlocking {
+        controller.failing += "bad"
+
+        val result = service.konstruct("bad")
+
+        assertEquals(1, controller.renderCalls, "the render has to have been attempted")
+        assertEquals(TaskStatus.FAILURE, result.status, "the render failed. Result: $result")
+        val info = service.getInfo(Unit)
+        assertNotEquals(
+            CLEAN,
+            info.dirtyState,
+            "a konstruction whose render just failed must not report itself clean. Info: $info"
+        )
+        assertEquals(
+            RENDER_FAILED,
+            info.dirtyState,
+            "the failure has to be stated, not just 'not clean'. Info: $info"
+        )
+    }
+
+    /**
+     * The other direction: nothing failed, so the konstruction really is clean. Without this,
+     * "never CLEAN" would satisfy the test above.
+     */
+    @Test
+    fun successfulRenderLeavesTheKonstructionClean() = runBlocking {
+        val result = service.konstruct("good")
+
+        assertEquals(1, controller.renderCalls, "the render has to have been attempted")
+        assertEquals(TaskStatus.SUCCESS, result.status, "the render succeeded. Result: $result")
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).dirtyState,
+            "a render in which everything built is clean"
+        )
+    }
+
+    /**
+     * The per-target states #113 established are untouched: the target that built is CLEAN and
+     * the one that failed stays NEEDS_EXEC, which is the retry route (#104).
+     */
+    @Test
+    fun failedRenderKeepsThePerTargetStatesFromIssue113() = runBlocking {
+        controller.failing += "bad"
+
+        service.konstruct("bad")
+
+        assertEquals(1, controller.renderCalls, "the render has to have been attempted")
+        val targets = service.getInfo(Unit).targets.associate { it.name to it.state }
+        assertEquals(CLEAN, targets["good"], "the target that built. Targets: $targets")
+        assertEquals(NEEDS_EXEC, targets["bad"], "the target that failed. Targets: $targets")
+    }
+
+    /**
+     * The konstruction-level state a failed render leaves must not close the retry route: the
+     * `:263` guard's second clause reads the per-target states, so a re-request still has to
+     * re-enter `render()`. This is what would break if the fix reached for CLEAN's opposite
+     * without checking what the guard actually keys on.
+     */
+    @Test
+    fun aFailedRenderCanStillBeRetried() = runBlocking {
+        controller.failing += "bad"
+        service.konstruct("bad")
+        assertEquals(1, controller.renderCalls, "first render")
+        assertEquals(RENDER_FAILED, service.getInfo(Unit).dirtyState, "first render failed")
+
+        controller.failing -= "bad"
+        val retry = service.konstruct("bad")
+
+        assertEquals(2, controller.renderCalls, "the retry has to re-enter render()")
+        assertEquals(TaskStatus.SUCCESS, retry.status, "the retry built. Result: $retry")
+        assertEquals(
+            CLEAN,
+            service.getInfo(Unit).dirtyState,
+            "a konstruction that has recovered goes back to clean"
+        )
+    }
+
+    /**
+     * Put [controller] into the process-wide [KonstructorManager] cache so the
+     * [KonstructionServiceImpl] built afterwards picks it up.
+     *
+     * There is no injection seam — the service resolves its controller through
+     * `KonstructorManager(config).controllerFor(...)` — and the cache is keyed by the [Config]
+     * instance (identity: `Config` is not a data class), so a fresh [TestEnvironment] cannot
+     * collide with another test's entry.
+     */
+    private fun installController(
+        config: Config,
+        workspaceId: String,
+        id: String,
+        controller: KonstructionController
+    ) {
+        val manager = KonstructorManager(config)
+        val field = KonstructorManager::class.java.getDeclaredField("controllers")
+        field.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val controllers =
+            field.get(manager) as MutableMap<Pair<String, String>, KonstructionController>
+        synchronized(controllers) {
+            controllers[workspaceId to id] = controller
+        }
+    }
+}
+
+/**
+ * A [KonstructionController] whose `render` reports what [ExecuteTask] would report, without
+ * kotlinc or a script subprocess.
+ *
+ * Targets named in [failing] error out; the rest build. Matching the real pipeline, the STL of
+ * every attempted target is deleted up front and only written back for the ones that built,
+ * and the render's [TaskResult] carries the built targets in `taskArguments` with FAILURE as
+ * soon as one target fails.
+ */
+private class FakeController(
+    config: Config,
+    private val allTargets: List<String>,
+    private val attemptedTargets: List<String>,
+    override var info: KonstructionInfo
+) : KonstructionController {
+    override val callSign: CallSign = CallSign("test.fake")
+    override val paths: PathController.Paths = PathController(config)["ws1", "k1"]
+    override val scriptLock: Mutex = Mutex()
+
+    /** Targets that error out at execute time. Mutable so a test can un-break one. */
+    val failing: MutableSet<String> = mutableSetOf()
+
+    /** How many times `render` was entered — a render that never ran proves nothing. */
+    var renderCalls: Int = 0
+        private set
+
+    private var renderResult: TaskResult? = null
+
+    override suspend fun render(targets: List<String>): RenderedTargets {
+        renderCalls++
+        paths.renderOutput.mkdirs()
+        val built = attemptedTargets.filter { it !in failing }
+        for (target in attemptedTargets) {
+            val file = File(paths.renderOutput, "$target.stl")
+            file.delete()
+            if (target in built) {
+                file.writeText("solid $target\nendsolid $target\n")
+            }
+        }
+        renderResult = TaskResult(
+            taskArguments = built,
+            status = if (built.size == attemptedTargets.size) {
+                TaskStatus.SUCCESS
+            } else {
+                TaskStatus.FAILURE
+            }
+        )
+        return RenderedTargets(allTargets, attemptedTargets)
+    }
+
+    override suspend fun hasRenderResult(): Boolean = renderResult != null
+
+    override suspend fun lastRenderResult(): TaskResult = renderResult ?: error("no render")
+
+    override suspend fun renderFile(target: String): File? =
+        File(paths.renderOutput, "$target.stl").takeIf { it.exists() }
+
+    override suspend fun read(): String = unsupported("read")
+
+    override suspend fun write(content: String) = unsupported("write")
+
+    override suspend fun write(content: ByteReadChannel) = unsupported("write")
+
+    override suspend fun compile() = unsupported("compile")
+
+    override suspend fun lastCompileResult(): TaskResult = unsupported("lastCompileResult")
+
+    private fun unsupported(name: String): Nothing =
+        throw UnsupportedOperationException("$name is not part of the render path under test")
+}

--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/viewmodel/KonstructionViewModel.kt
@@ -48,6 +48,16 @@ enum class UiState {
     EXECUTING
 }
 
+/**
+ * Dirty states that mean "a build has already run for this konstruction", so the UI should
+ * show what exists rather than kicking off a compile/build cycle of its own.
+ *
+ * [DirtyState.RENDER_FAILED] belongs here for the same reason it must never join the
+ * [DirtyState.NEEDS_EXEC] branch: auto-requesting a build for a render that just failed
+ * simply fails again and re-notifies, forever (#117).
+ */
+private val SETTLED_STATES = setOf(DirtyState.CLEAN, DirtyState.RENDER_FAILED)
+
 class KonstructionViewModel(
     private val serviceHolder: ServiceHolder,
     private val targetDisplayRepo: TargetDisplayRepository
@@ -212,9 +222,13 @@ class KonstructionViewModel(
                 if (info != null) {
                     targetDisplayRepo.mergeTargets(info.targets.map { it.name })
                 }
-                // If already CLEAN, fetch existing render paths in parallel;
-                // otherwise trigger a compile/build cycle.
-                if (info != null && info.dirtyState == DirtyState.CLEAN) {
+                // If the last build already ran, fetch existing render paths in parallel;
+                // otherwise trigger a compile/build cycle. RENDER_FAILED counts as "already
+                // ran": the render was attempted and failed, so re-driving compile+build on
+                // every load would just repeat it. Its targets that DID build are still
+                // CLEAN, and applyCleanRenders only reads those — which is exactly what this
+                // did while a failed render reported the konstruction CLEAN (#117).
+                if (info != null && info.dirtyState in SETTLED_STATES) {
                     applyCleanRenders(ks, info)
                 } else {
                     autoCompileAndBuild(ks)
@@ -321,7 +335,11 @@ class KonstructionViewModel(
                     }
                 }
 
-                DirtyState.CLEAN -> {
+                // RENDER_FAILED shares this branch and must NOT share the NEEDS_EXEC one:
+                // requesting a build for a render that just failed loops forever. Settling
+                // here (and showing whatever did build) is what the frontend already did
+                // back when a failed render reported the konstruction CLEAN (#117).
+                DirtyState.CLEAN, DirtyState.RENDER_FAILED -> {
                     _state.value = UiState.DEFAULT
                     applyCleanRenders(ks, info)
                 }

--- a/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructorTypes.kt
+++ b/protocol/src/commonMain/kotlin/com/monkopedia/konstructor/common/KonstructorTypes.kt
@@ -36,7 +36,22 @@ data class Konstruction(
 enum class DirtyState {
     CLEAN,
     NEEDS_COMPILE,
-    NEEDS_EXEC
+    NEEDS_EXEC,
+
+    /**
+     * The last render was attempted and failed: at least one target it tried to build
+     * errored out at execute time.
+     *
+     * Distinct from [NEEDS_EXEC] on purpose. [NEEDS_EXEC] means "not built yet, go build it",
+     * and the frontend auto-requests a build whenever it sees it. Reporting a failed render as
+     * [NEEDS_EXEC] would therefore drive render -> fail -> info change -> re-request forever,
+     * which is why the konstruction-level state used to be forced to [CLEAN] instead (#117).
+     * This state says "the build ran and did not work" without asking anyone to run it again;
+     * a retry is still available through the per-target states, which stay [NEEDS_EXEC].
+     *
+     * Appended last so the ordinals and serial names of the existing entries are unchanged.
+     */
+    RENDER_FAILED
 }
 
 @Serializable

--- a/protocol/src/commonTest/kotlin/com/monkopedia/konstructor/common/KonstructorTypesTest.kt
+++ b/protocol/src/commonTest/kotlin/com/monkopedia/konstructor/common/KonstructorTypesTest.kt
@@ -147,10 +147,12 @@ class KonstructorTypesTest {
     @Test
     fun testDirtyStateValues() {
         val values = DirtyState.entries
-        assertEquals(3, values.size)
+        assertEquals(4, values.size)
         assertEquals(DirtyState.CLEAN, values[0])
         assertEquals(DirtyState.NEEDS_COMPILE, values[1])
         assertEquals(DirtyState.NEEDS_EXEC, values[2])
+        // Appended last (#117) so the entries above keep their ordinals and serial names.
+        assertEquals(DirtyState.RENDER_FAILED, values[3])
     }
 
     @Test


### PR DESCRIPTION
## What

`KonstructionServiceImpl.konstruct()` wrote `dirtyState = CLEAN` after every render, including one that failed (`KonstructionServiceImpl.kt:299` on main). Since #113 / #123 the **per-target** states are accurate, so nothing was stuck — but the konstruction-level flag claimed "clean" about a konstruction whose last render had just failed, and `ScriptHostImpl.findScript()` reads exactly that flag to decide whether an imported konstruction still needs compiling.

## The two traps the issue named, and how this avoids them

**1. "Just report NEEDS_EXEC" would loop the frontend forever.** `KonstructionViewModel.onInfoChanged()` fires `requestKonstructs(...)` whenever it sees `NEEDS_EXEC`, so a permanently-failing target would drive render → fail → info change → re-request, without end. The unconditional `CLEAN` was load-bearing, not sloppy.

So this adds a **fourth `DirtyState`: `RENDER_FAILED`** — appended last, so every existing entry keeps its ordinal and serial name. It means *"the build ran and did not work"* and asks nobody to run it again. The frontend treats it **exactly** as it treated the `CLEAN` that used to be reported on this path: settle the UI, show whatever did build, do not auto-retry. Frontend behaviour after a failed render is therefore unchanged by this PR; only the backend's honesty about it changes.

**2. "Dirty if any target is dirty" would pin the flag forever** for a script with a declared-but-never-exported target. Avoided by keying on what the render **reported** (`lastRenderResult().status`, which `ExecuteTask` fails as soon as any *attempted* target errors) rather than on whether any target is dirty. A never-attempted target cannot make the konstruction `RENDER_FAILED`.

## The per-target logic from #113 / #123 is untouched

No line of the `when` that derives per-target state was changed. The retry route is unchanged and still the per-target `NEEDS_EXEC` that the second clause of the `konstruct()` guard reads (#104) — `KonstructionServiceDirtyStateTest` asserts both explicitly, so a future change that quietly undoes either fails here.

## One intentional behaviour change

`ScriptHostImpl.findScript()` gates on `dirtyState != CLEAN`, so it now sees `RENDER_FAILED` and recompiles an imported konstruction whose last render failed (it previously did not, because the flag lied). That gate is precisely the consumer the issue cited as being misled; recompiling is the conservative answer to "the last build was not good". Flagged here because it is the one place where reading the truth changes what happens rather than only what is reported.

## Test, and the RED control

`backend/src/jvmTest/.../KonstructionServiceDirtyStateTest.kt` drives a render through a fake `KonstructionController` that reproduces `ExecuteTask`'s contract (built targets in `taskArguments`, FAILURE as soon as one attempted target errors), so it runs in the **ordinary `:backend:jvmTest`** rather than behind `-Dintegration=true`.

Every case asserts `renderCalls` as well as the state. The `konstruct()` guard can skip `render()` **silently**, and dirty-state tests in this repo have passed vacuously that way before, so "the render actually ran" is asserted rather than assumed.

Measured, `:backend:jvmTest` in full (no `--tests` filter), on kaladin under the build slot:

| | tests | failed | skipped |
|---|---|---|---|
| **RED** — only `dirtyState = if (...) CLEAN else RENDER_FAILED` reverted to `dirtyState = CLEAN` | 164 | **2** | 19 |
| **GREEN** — fix in place | 164 | **0** | 19 |

The RED failures are `failedRenderDoesNotLeaveTheKonstructionClean` and `aFailedRenderCanStillBeRetried`; the other two cases in the class stay green, so the test is not merely "always fails". The mutation is one expression — the enum, the test, and every signature stayed intact, and the RED run compiled and executed 164 tests rather than dying at compile time.

`:protocol:jvmTest` (17 tests, 0 failed), `:frontend:compileKotlinWasmJs` and `spotlessCheck` all pass on the fix.

## Scope

Deliberately does **not** touch #115 (LSP respawn cap — different file entirely) or #116 (the `onRenderChanged` broadcast loop and `render()`'s STL-deletion set). #116's territory is `KonstructionServiceImpl.kt:303-317` plus `KonstructionController.kt:128`; neither is modified here. The two changes are adjacent inside `konstruct()` but do not overlap.

Not fixed, noted: `compile()` has the same shape of lie — a **compile** failure also writes `dirtyState = CLEAN` (`:206`). Out of scope for this issue, which is about the render path.

Fixes #117
