### PR TITLE
e2e: one Playwright driver + browser per test class, not per test method (#124)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,6 @@ jobs:
             libhyphen0 \
             libicu74 || true
 
-      # The Ktor CIO / Netty server and WebSocket use a lot of file descriptors
-      # during the e2e runs; bump the limit.
-      - name: Raise file descriptor limit
-        run: ulimit -n 4096 || true
-
       - name: Spotless check
         run: ./gradlew spotlessCheck
 

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/BaseE2eTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/BaseE2eTest.kt
@@ -36,25 +36,15 @@ abstract class BaseE2eTest {
     protected lateinit var server: ServerFixture
     protected lateinit var page: Page
 
-    private var playwright: Playwright? = null
-    private var browser: Browser? = null
-
     protected val json = Json { ignoreUnknownKeys = true }
 
     @org.junit.Before
     fun setUpBase() {
         server = ServerFixture()
         server.start()
-        if (playwright == null) {
-            playwright = Playwright.create()
-            // Compose/Skiko needs a real display for WebGL rendering.
-            // Use headed mode (Xvfb provides a virtual display in CI).
-            browser = playwright!!.chromium().launch(
-                BrowserType.LaunchOptions()
-                    .setHeadless(false)
-            )
-        }
-        page = browser!!.newPage()
+        // One page (and so one fresh browser context) per test method; the
+        // browser and driver behind it are shared for the whole class.
+        page = browser().newPage()
         page.onConsoleMessage { msg ->
             if (msg.type() == "error" || msg.type() == "warning" || msg.type() == "log") {
                 System.err.println("[browser:${msg.type()}] ${msg.text()}")
@@ -69,12 +59,6 @@ abstract class BaseE2eTest {
     fun tearDownBase() {
         if (::page.isInitialized) page.close()
         server.stop()
-    }
-
-    // Clean up Playwright at end (called by JVM shutdown, not per-test)
-    protected fun finalize() {
-        browser?.close()
-        playwright?.close()
     }
 
     // -- Bridge helpers -------------------------------------------------------
@@ -271,6 +255,45 @@ abstract class BaseE2eTest {
     protected fun waitOpts(timeout: Double) = Page.WaitForSelectorOptions().setTimeout(timeout)
 
     companion object {
+        /**
+         * The Playwright driver and browser are held on the **class**, not on the
+         * instance: JUnit 4 constructs a new test-class instance for every `@Test`
+         * method, so instance fields here meant one Node driver process plus one
+         * headed Chromium per test method, all of them retained for the life of
+         * the test JVM (issue #124). They are created once per test class in
+         * [startBrowser] and closed in [stopBrowser], so at most one of each is
+         * ever alive. [HarnessLifecycleTest] asserts that property.
+         */
+        private var playwright: Playwright? = null
+        private var browser: Browser? = null
+
+        @JvmStatic
+        @org.junit.BeforeClass
+        fun startBrowser() {
+            if (playwright == null) {
+                playwright = Playwright.create()
+                // Compose/Skiko needs a real display for WebGL rendering.
+                // Use headed mode (Xvfb provides a virtual display in CI).
+                browser = playwright!!.chromium().launch(
+                    BrowserType.LaunchOptions()
+                        .setHeadless(false)
+                )
+            }
+        }
+
+        @JvmStatic
+        @org.junit.AfterClass
+        fun stopBrowser() {
+            browser?.close()
+            browser = null
+            playwright?.close()
+            playwright = null
+        }
+
+        private fun browser(): Browser = checkNotNull(browser) {
+            "Browser not started; @BeforeClass startBrowser() did not run"
+        }
+
         /** Default timeout for a generic [waitForState] predicate. */
         const val DEFAULT_STATE_TIMEOUT: Double = 30000.0
 

--- a/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/HarnessLifecycleTest.kt
+++ b/e2e/src/test/kotlin/com/monkopedia/konstructor/e2e/HarnessLifecycleTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.e2e
+
+import java.util.stream.Collectors
+import kotlin.test.assertEquals
+import org.junit.Test
+
+/**
+ * Guards the browser lifecycle of the harness itself (issue #124).
+ *
+ * JUnit 4 builds a **new instance of the test class for every `@Test` method**,
+ * so any Playwright/Browser held in an *instance* field is created once per
+ * method and — unless something closes it — retained for the life of the test
+ * JVM. That leak is invisible to a single-method check: it only shows up as
+ * growth across methods. Hence three methods that each assert the same
+ * invariant.
+ *
+ * The measurement is of **real OS processes**, not of a harness counter: every
+ * `Playwright.create()` spawns a Node driver process as a child of the test JVM,
+ * and the browser it launches is a descendant of that driver. Counting live
+ * descendants is therefore a direct count of leaked drivers/browsers.
+ *
+ * The assertion is `== 1`, never `<= 1`, deliberately: if the command-line
+ * filter below ever stops matching the driver, the count collapses to 0 and the
+ * test fails instead of passing vacuously. A check that cannot fail is not a
+ * check.
+ */
+class HarnessLifecycleTest : BaseE2eTest() {
+
+    @Test
+    fun onlyOneDriverAlive_1() = assertSingleDriverProcess("method 1")
+
+    @Test
+    fun onlyOneDriverAlive_2() = assertSingleDriverProcess("method 2")
+
+    @Test
+    fun onlyOneDriverAlive_3() = assertSingleDriverProcess("method 3")
+
+    private fun assertSingleDriverProcess(label: String) {
+        // Closing a browser/driver is asynchronous; give a leftover process a
+        // moment to actually exit before deciding it leaked. A genuine leak
+        // never drops, so this only removes flake, not the failure.
+        val drivers = awaitSettled { driverCommandLines() }
+        val browsers = browserCommandLines()
+        System.err.println(
+            "[harness-lifecycle] $label: playwright drivers alive=${drivers.size}, " +
+                "browser processes alive=${browsers.size}"
+        )
+        if (drivers.size != 1) {
+            System.err.println("[harness-lifecycle] all JVM descendants:")
+            descendantCommandLines().forEach { System.err.println("[harness-lifecycle]   $it") }
+        }
+        assertEquals(
+            1,
+            drivers.size,
+            "Expected exactly one live Playwright driver process for the whole test " +
+                "class, found ${drivers.size} ($label). More than one means the harness " +
+                "creates a driver per test method and never closes it (issue #124); " +
+                "zero means the driver-detection filter no longer matches."
+        )
+    }
+
+    private fun awaitSettled(timeoutMs: Long = 5000, count: () -> List<String>): List<String> {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var current = count()
+        while (current.size > 1 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(250)
+            current = count()
+        }
+        return current
+    }
+
+    private fun descendantCommandLines(): List<String> = ProcessHandle.current().descendants()
+        .map { it.info().commandLine().orElse("") }
+        .collect(Collectors.toList())
+
+    /** Node driver processes: `<driver>/node <driver>/package/cli.js run-driver`. */
+    private fun driverCommandLines(): List<String> =
+        descendantCommandLines().filter { it.contains("run-driver") }
+
+    /** Top-level browser processes (renderers/GPU helpers carry `--type=`). */
+    private fun browserCommandLines(): List<String> = descendantCommandLines().filter {
+        (it.contains("chrome") || it.contains("chromium") || it.contains("headless_shell")) &&
+            !it.contains("--type=") && !it.contains("run-driver")
+    }
+}


### PR DESCRIPTION
## What

`BaseE2eTest` held `playwright` / `browser` in **instance** fields. JUnit 4 constructs a new instance of the test class for every `@Test` method, so the `if (playwright == null)` guard — clearly written to make them one-per-class — was always true, and every test method spawned its own Node driver process plus its own **headed** Chromium. Nothing closed them: `tearDownBase()` closes only the page and the server, and the `finalize()` that carried the comment *"called by JVM shutdown"* is not called by JVM shutdown at all (finalization is deprecated for removal, JEP 421; it runs at an unspecified GC, if ever). The comment was load-bearing for the omission.

- Moved `playwright` / `browser` to the companion object, created in `@BeforeClass`, closed in `@AfterClass`.
- Deleted `finalize()` and its comment.
- `page = browser.newPage()` stays per-method: `Browser.newPage()` creates its own browser context, so **per-test isolation (localStorage etc.) is unchanged**.
- Added `HarnessLifecycleTest` as the regression guard.
- **Deleted the `Raise file descriptor limit` CI step** (see below).

## The control — RED and GREEN, measured

The defect is *resource retention across test methods*, which a single-method check cannot see: it passes identically before and after. So `HarnessLifecycleTest` has three methods that each count **real OS processes** — `ProcessHandle.current().descendants()` filtered to the Playwright `run-driver` node process — and assert exactly one live driver.

Run locally under Xvfb (`:e2e:test -Pe2e --tests "*HarnessLifecycleTest"`), same test file both times, only `BaseE2eTest` differing:

| | method 1 | method 2 | method 3 | result |
|---|---|---|---|---|
| **RED** (harness as on `main`) | drivers **1**, browser procs 8 | drivers **2**, browser procs 14 | drivers **3**, browser procs 20 | `3 tests completed, 2 failed` |
| **GREEN** (this branch) | drivers **1**, browser procs 8 | drivers **1**, browser procs 8 | drivers **1**, browser procs 8 | `tests="3" failures="0"` |

The leak scales exactly with N: **+1 driver and +6 browser processes per test method**, none of them released. Extrapolated over the current 45 `@Test` methods that is ~45 drivers and ~270 browser processes held to the end of the run — but note the 45-method figure is extrapolation; what was measured is the per-method growth rate.

The RED came from running the control against the **unmodified** harness (the API it compiles against is untouched — it only counts processes), so it is a failing test, not a compile failure.

The assertion is `== 1`, never `<= 1`: if the process filter ever stops matching the driver, the count collapses to 0 and the test **fails** rather than passing vacuously. On any mismatch it dumps every JVM descendant command line so the filter can be repaired rather than guessed at.

**Cross-class check** (`--tests "*AppLoadTest" --tests "*HarnessLifecycleTest"`): `HarnessLifecycleTest` ran *after* `AppLoadTest` (timestamps 17:07:32 vs 17:07:27) and still saw exactly 1 driver — so `@AfterClass` really does release the previous class's driver, and the fix is one-at-a-time across the whole run, not merely one-per-class-retained.

**Full suite**, this branch, locally under Xvfb: 20 classes, 48 tests, 9 skipped, **0 failures**, 3m13s.

## The CI step

```yaml
      # The Ktor CIO / Netty server and WebSocket use a lot of file descriptors
      # during the e2e runs; bump the limit.
      - name: Raise file descriptor limit
        run: ulimit -n 4096 || true
```

Each `run:` step is its own shell process, so this raised the limit for a shell that exited immediately — **zero effect on any later step**, including the e2e run it was added for, and `|| true` meant it could never fail visibly. Whatever fd pressure the suite was under has been completely unmitigated the entire time. Deleted rather than repaired: a step asserting a mitigation that does not exist is worse than no step, because the next reader sees fd pressure as handled.

**If a raised limit is actually wanted**, it has to be inside the same step that runs the tests:

```yaml
      - name: Run e2e tests under Xvfb
        run: ulimit -n 4096 && xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' ./gradlew :e2e:test -Pe2e
```

I did not do that — with the leak fixed the pressure this was aimed at is gone, and inlining it would re-assert a mitigation nobody has measured a need for. Say the word and I will add it.

## Not verified

- Only run on this Linux box (Arch + Mesa EGL override for Xvfb) and not yet in CI; the process-count filter is Linux-specific (`/proc`-backed `ProcessHandle.Info.commandLine()`), which matches the ubuntu-latest runner.
- The ~45-driver whole-suite figure is extrapolated from the measured per-method growth, not counted at the end of a full pre-fix run.

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
