### PR TITLE
TestBridge: build every snapshot through buildSnapshot (#106)

### DIFF
--- a/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
+++ b/frontend/src/wasmJsMain/kotlin/com/monkopedia/konstructor/frontend/JsBridge.kt
@@ -148,7 +148,7 @@ object JsBridge {
                     val workspaceId = args["workspaceId"]!!.jsonPrimitive.content
                     mutations.createKonstruction(workspaceId, name)
                     // Refresh state so konstructions list updates
-                    refreshKonstructions(serviceHolder, spaceListVm)
+                    refreshKonstructions(serviceHolder, spaceListVm, settingsVm, konstructionVm)
                 } catch (e: Exception) {
                     setError("createKonstruction failed: ${e.message}")
                 }
@@ -163,7 +163,7 @@ object JsBridge {
                     val kon = mutations.findKonstruction(wsId, konId)
                     if (kon != null) {
                         mutations.deleteKonstruction(kon)
-                        refreshKonstructions(serviceHolder, spaceListVm)
+                        refreshKonstructions(serviceHolder, spaceListVm, settingsVm, konstructionVm)
                     }
                 } catch (e: Exception) {
                     setError("deleteKonstruction failed: ${e.message}")
@@ -178,7 +178,7 @@ object JsBridge {
                     val konId = args["konId"]!!.jsonPrimitive.content
                     val name = args["name"]!!.jsonPrimitive.content
                     mutations.renameKonstruction(wsId, konId, name)
-                    refreshKonstructions(serviceHolder, spaceListVm)
+                    refreshKonstructions(serviceHolder, spaceListVm, settingsVm, konstructionVm)
                 } catch (e: Exception) {
                     setError("renameKonstruction failed: ${e.message}")
                 }
@@ -441,9 +441,23 @@ object JsBridge {
 
     private var refreshTriggerRef: kotlinx.coroutines.flow.MutableStateFlow<Int>? = null
 
-    private suspend fun refreshKonstructions(
+    /**
+     * Publish a snapshot after a konstruction-list mutation, without waiting for
+     * the reactive `combine` in [install] to catch up.
+     *
+     * Every field comes from [buildSnapshot] (issue #106). This used to hand-build
+     * its own [AppStateSnapshot], which hardcoded `codePaneMode = "EDITOR"` and
+     * left `lspEnabled`/`editorTheme`/`keymap`/targets/diagnostics on their
+     * data-class defaults — so the bridge, which is the only instrument e2e has
+     * for reading app state, reported state the app was not in. Keep the single
+     * construction site: a new snapshot field must only ever be added inside
+     * [buildSnapshot].
+     */
+    internal suspend fun refreshKonstructions(
         serviceHolder: ServiceHolder,
-        spaceListVm: SpaceListViewModel
+        spaceListVm: SpaceListViewModel,
+        settingsVm: SettingsViewModel,
+        konstructionVm: KonstructionViewModel?
     ) {
         // Directly update the state snapshot with current konstruction list
         spaceListVm.refreshWorkspaces()
@@ -454,18 +468,13 @@ object JsBridge {
             if (service != null && wsId != null) {
                 val ws = service.get(wsId)
                 val kons = ws.list()
-                val workspaces = spaceListVm.workspaces.value
-                val snapshot = AppStateSnapshot(
-                    ready = true,
+                val snapshot = buildSnapshot(
                     connected = serviceHolder.connected.value,
-                    workspaceCount = workspaces?.size ?: 0,
-                    workspaceNames = workspaces?.map { it.name } ?: emptyList(),
-                    workspaceIds = workspaces?.map { it.id } ?: emptyList(),
-                    selectedWorkspaceId = wsId,
-                    codePaneMode = "EDITOR",
-                    screen = "main",
-                    konstructionCount = kons.size,
-                    konstructionNames = kons.map { it.name }
+                    workspaces = spaceListVm.workspaces.value,
+                    selectedWsId = wsId,
+                    konNames = kons.map { it.name },
+                    settingsVm = settingsVm,
+                    konstructionVm = konstructionVm
                 )
                 val stateJson = json.encodeToString(AppStateSnapshot.serializer(), snapshot)
                 setState(stateJson)

--- a/frontend/src/wasmJsTest/kotlin/com/monkopedia/konstructor/frontend/JsBridgeRefreshSnapshotTest.kt
+++ b/frontend/src/wasmJsTest/kotlin/com/monkopedia/konstructor/frontend/JsBridgeRefreshSnapshotTest.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.konstructor.frontend
+
+import com.monkopedia.hauler.Shipper
+import com.monkopedia.konstructor.common.Konstruction
+import com.monkopedia.konstructor.common.KonstructionService
+import com.monkopedia.konstructor.common.Konstructor
+import com.monkopedia.konstructor.common.Space
+import com.monkopedia.konstructor.common.Workspace
+import com.monkopedia.konstructor.frontend.viewmodel.CodePaneMode
+import com.monkopedia.konstructor.frontend.viewmodel.ConnectionFactory
+import com.monkopedia.konstructor.frontend.viewmodel.EditorThemeName
+import com.monkopedia.konstructor.frontend.viewmodel.KeymapName
+import com.monkopedia.konstructor.frontend.viewmodel.ServiceConnection
+import com.monkopedia.konstructor.frontend.viewmodel.ServiceHolder
+import com.monkopedia.konstructor.frontend.viewmodel.SettingsViewModel
+import com.monkopedia.konstructor.frontend.viewmodel.SpaceListViewModel
+import com.monkopedia.konstructor.frontend.viewmodel.WorkspaceMutations
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * `globalThis.__konstructor.state` is the ONLY channel the Playwright e2e suite
+ * has for reading app state — Compose renders to a WebGL canvas, so there are no
+ * DOM selectors. A snapshot that reports data-class defaults instead of real
+ * view-model state therefore lets an e2e assertion pass (or fail) describing
+ * state the app is not in.
+ *
+ * Issue #106: [JsBridge.refreshKonstructions] hand-built its own
+ * [AppStateSnapshot] rather than going through `buildSnapshot`. It hardcoded
+ * `codePaneMode = "EDITOR"` and never passed `editorTheme`, `keymap` or
+ * `lspEnabled` at all, so those three silently took the data-class defaults on
+ * every konstruction create/rename/delete.
+ *
+ * These tests drive all four fields OFF both their view-model defaults and their
+ * [AppStateSnapshot] defaults before triggering the refresh, then read the
+ * published JSON back out of `globalThis`. A test that left them on their
+ * defaults would pass identically against the unfixed code — which is exactly
+ * the class of bug this file exists to catch — so
+ * [theInstrumentWouldDetectAFieldReportingItsDefault] asserts, on the values
+ * this file uses, that each one really does differ from the default it would
+ * have been reported as.
+ */
+class JsBridgeRefreshSnapshotTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Deliberately not the AppStateSnapshot default, and not the
+    // SettingsViewModel default either, so neither can produce a false pass.
+    private val expectedPaneMode = CodePaneMode.SETTINGS
+    private val expectedTheme = EditorThemeName.TOMORROW
+    private val expectedKeymap = KeymapName.EMACS
+    private val expectedLspEnabled = false
+
+    @Test
+    fun theInstrumentWouldDetectAFieldReportingItsDefault() {
+        // If any of these ever coincides with the default, the corresponding
+        // assertion below becomes vacuous: it would pass against the pre-fix
+        // hand-built snapshot too.
+        val defaults = AppStateSnapshot()
+        assertNotEquals(defaults.codePaneMode, expectedPaneMode.name)
+        assertNotEquals(defaults.editorTheme, expectedTheme.name)
+        assertNotEquals(defaults.keymap, expectedKeymap.name)
+        assertNotEquals(defaults.lspEnabled, expectedLspEnabled)
+        // The pre-fix site also hardcoded EDITOR regardless of the defaults.
+        assertNotEquals("EDITOR", expectedPaneMode.name)
+    }
+
+    @Test
+    fun refreshKonstructionsPublishesRealSettingsNotDefaults() = runTest {
+        val fixture = bridgeFixture(backgroundScope)
+
+        fixture.settingsVm.setCodePaneMode(expectedPaneMode)
+        fixture.settingsVm.setEditorTheme(expectedTheme)
+        fixture.settingsVm.setKeymap(expectedKeymap)
+        fixture.settingsVm.setLspEnabled(expectedLspEnabled)
+        fixture.spaceListVm.selectWorkspace(WORKSPACE_ID)
+        runCurrent()
+
+        testInitBridge()
+        JsBridge.refreshKonstructions(
+            serviceHolder = fixture.serviceHolder,
+            spaceListVm = fixture.spaceListVm,
+            settingsVm = fixture.settingsVm,
+            konstructionVm = null
+        )
+        advanceUntilIdle()
+
+        val state = publishedSnapshot()
+
+        // Instrument check: the refresh really did publish, and really did reach
+        // the konstruction list. Without this a snapshot of all-defaults could be
+        // mistaken for "no publish happened".
+        assertEquals(
+            listOf("alpha", "beta"),
+            state.konstructionNames,
+            "refresh should have published the current konstruction list"
+        )
+
+        // The four fields issue #106 is about, compared as one list so a
+        // regression reports every field that drifted, not just the first.
+        assertEquals(
+            listOf(
+                "codePaneMode=${expectedPaneMode.name}",
+                "editorTheme=${expectedTheme.name}",
+                "keymap=${expectedKeymap.name}",
+                "lspEnabled=$expectedLspEnabled"
+            ),
+            listOf(
+                "codePaneMode=${state.codePaneMode}",
+                "editorTheme=${state.editorTheme}",
+                "keymap=${state.keymap}",
+                "lspEnabled=${state.lspEnabled}"
+            ),
+            "refreshKonstructions must publish real view-model state, not defaults"
+        )
+    }
+
+    @Test
+    fun refreshKonstructionsDoesNotClobberSettingsPublishedByTheMainSnapshot() = runTest {
+        // The e2e-visible failure mode: a test sets a mode, something creates or
+        // deletes a konstruction, and the bridge then reports the mode back to
+        // its default. Assert the value SURVIVES the refresh rather than merely
+        // being present in one snapshot.
+        val fixture = bridgeFixture(backgroundScope)
+        fixture.settingsVm.setCodePaneMode(expectedPaneMode)
+        fixture.settingsVm.setKeymap(expectedKeymap)
+        fixture.spaceListVm.selectWorkspace(WORKSPACE_ID)
+        runCurrent()
+
+        testInitBridge()
+        repeat(2) {
+            JsBridge.refreshKonstructions(
+                serviceHolder = fixture.serviceHolder,
+                spaceListVm = fixture.spaceListVm,
+                settingsVm = fixture.settingsVm,
+                konstructionVm = null
+            )
+            advanceUntilIdle()
+            val state = publishedSnapshot()
+            assertEquals(expectedPaneMode.name, state.codePaneMode, "after refresh #${it + 1}")
+            assertEquals(expectedKeymap.name, state.keymap, "after refresh #${it + 1}")
+        }
+    }
+
+    private fun publishedSnapshot(): AppStateSnapshot {
+        val raw = readBridgeStateJson()
+        assertNotNull(raw, "nothing was published to globalThis.__konstructor.state")
+        return json.decodeFromString(AppStateSnapshot.serializer(), raw)
+    }
+}
+
+private const val WORKSPACE_ID = "ws-1"
+
+private class BridgeFixture(
+    val serviceHolder: ServiceHolder,
+    val spaceListVm: SpaceListViewModel,
+    val settingsVm: SettingsViewModel
+)
+
+private fun bridgeFixture(scope: CoroutineScope): BridgeFixture {
+    val serviceHolder = ServiceHolder(
+        ConnectionFactory { FakeServiceConnection() },
+        scope
+    )
+    val spaceListVm = SpaceListViewModel(serviceHolder, WorkspaceMutations(serviceHolder))
+    return BridgeFixture(serviceHolder, spaceListVm, SettingsViewModel())
+}
+
+private class FakeServiceConnection : ServiceConnection {
+    override val stub: Konstructor = FakeKonstructor()
+    override suspend fun close() = Unit
+}
+
+private class FakeKonstructor : Konstructor {
+    override suspend fun ping(u: Unit) = Unit
+    override suspend fun list(u: Unit): List<Space> = listOf(Space(WORKSPACE_ID, "Workspace 1"))
+    override suspend fun get(id: String): Workspace = FakeWorkspace(id)
+    override suspend fun konstruction(id: Konstruction): KonstructionService = error("unused")
+    override suspend fun create(newItem: Space): Space = error("unused")
+    override suspend fun delete(item: Space) = error("unused")
+    override suspend fun getGlobalShipper(u: Unit): Shipper = error("unused")
+}
+
+private class FakeWorkspace(private val workspaceId: String) : Workspace {
+    override suspend fun list(u: Unit): List<Konstruction> = listOf(
+        Konstruction(name = "alpha", workspaceId = workspaceId, id = "k1"),
+        Konstruction(name = "beta", workspaceId = workspaceId, id = "k2")
+    )
+
+    override suspend fun create(newItem: Konstruction): Konstruction = error("unused")
+    override suspend fun delete(item: Konstruction) = error("unused")
+    override suspend fun getName(u: Unit): String = "Workspace 1"
+    override suspend fun setName(name: String) = error("unused")
+}
+
+/**
+ * Stand-ins for JsBridge's own private `initBridge`/`setState` externs, reading
+ * the same `globalThis.__konstructor.state` the Playwright suite reads.
+ */
+@JsFun("() => { globalThis.__konstructor = { ready: false, version: 0, state: null }; }")
+private external fun testInitBridge()
+
+@JsFun(
+    "() => { " +
+        "const s = globalThis.__konstructor && globalThis.__konstructor.state; " +
+        "return s == null ? '' : JSON.stringify(s); " +
+        "}"
+)
+private external fun readBridgeStateJsonRaw(): String
+
+private fun readBridgeStateJson(): String? = readBridgeStateJsonRaw().ifEmpty { null }


### PR DESCRIPTION
`JsBridge.refreshKonstructions` hand-built its own `AppStateSnapshot` instead of going through the existing `buildSnapshot` helper. It hardcoded `codePaneMode = "EDITOR"` and never passed `editorTheme`, `keymap`, `lspEnabled`, `targets` or `diagnostics` at all, so those silently took their data-class defaults on every konstruction create / rename / delete.

## Why this is worth more than its diff size

`globalThis.__konstructor.state` is the **only** channel the Playwright e2e suite has for reading app state — Compose renders to a WebGL canvas, so there are no DOM selectors and the TestBridge *is* the instrument. A snapshot that reports defaults instead of reality lets an e2e assertion pass or fail describing state the app is not in. It is benign today only because no current test reads those fields across a refresh — luck, not safety.

## The fix removes the class, not the instance

Rather than adding the missing fields to the second site (which leaves the next added field free to drift), `refreshKonstructions` now takes `settingsVm` / `konstructionVm` and calls `buildSnapshot`.

Construction-site enumeration, `git grep -n 'AppStateSnapshot('` over the whole repo:

| | before | after |
|---|---|---|
| declaration (`BridgeStateSnapshot.kt:40`) | 1 | 1 |
| construction sites | **2** (`JsBridge.kt:417` correct, `JsBridge.kt:458` hand-built) | **1** (`JsBridge.kt:417`, inside `buildSnapshot`) |

Denominator: 7 `AppStateSnapshot` mentions repo-wide before the change (declaration, 2 constructions, 2 `serializer()` calls, 1 KDoc, 1 return type); no third construction site exists in any module. A new snapshot field now has exactly one place it can be added.

Two smaller behaviours also become correct, both previously wrong at the hand-built site: `screen` is computed rather than hardcoded `"main"`, and an unloaded workspace list reports `workspaceCount = -1` (the documented "unknown" value) instead of `0`.

## RED / GREEN control

New `JsBridgeRefreshSnapshotTest` in `:frontend`'s `wasmJsTest` source set (added in #136, wired into CI). It drives all four fields off **both** their `SettingsViewModel` defaults and their `AppStateSnapshot` defaults, triggers the refresh, and reads the published JSON back out of `globalThis` — the same channel e2e reads, not an internal return value.

Measured on ChromeHeadless 151, `:frontend:wasmJsBrowserTest`, XML deleted before each run and the task confirmed `executed`:

- **GREEN** (fix in place): `6 tests completed, 0 failed` — `JsBridgeRefreshSnapshotTest tests="3" failures="0"`, `ServiceHolderConnectionLeakTest tests="3" failures="0"`. `spotlessCheck` green in the same invocation.
- **RED** (surgical mutation: only the snapshot-construction body reverted to the pre-fix hand-built form, the new signature left intact so it still compiles): `6 tests completed, 2 failed` —
  ```
  refreshKonstructions must publish real view-model state, not defaults.
  Expected <[codePaneMode=SETTINGS, editorTheme=TOMORROW, keymap=EMACS, lspEnabled=false]>,
   actual <[codePaneMode=EDITOR,   editorTheme=DRACULA,   keymap=VIM,    lspEnabled=true]>.
  ```

Note the RED actual: `editorTheme=DRACULA` is not even `SettingsViewModel`'s default (`ONE_DARK`) — it is the `AppStateSnapshot` default. The old snapshot reported a theme the app had never been in.

**Would the RED have passed vacuously?** Yes, had the fields not been driven off their defaults — that is exactly the failure mode this issue is about. Two guards against it:
1. `theInstrumentWouldDetectAFieldReportingItsDefault` asserts each chosen value differs from the default it would otherwise have been reported as, so the behavioural assertions cannot quietly go vacuous if someone changes a constant.
2. An instrument check on `konstructionNames` proves the refresh actually published and reached the konstruction list — so "all defaults" can never be mistaken for "no publish happened". That check **passes in RED**, which is what makes the RED a real red rather than a no-op.

The four fields are compared as one list so a regression reports every field that drifted rather than only the first (the first RED run stopped at `codePaneMode` and never proved the other three were live; the list form does).

## Not done

The issue also suggests an e2e assertion that a konstruction-unrelated field survives `refreshKonstructions`. Deliberately skipped: it would need a full `shadowJar` + Playwright run to verify, and shipping an unrun e2e test is worse than none. The unit test above observes the same value through the same `globalThis.__konstructor.state` channel, runs in ~6s in CI, and gives a measured RED. Happy to add the e2e assertion if you'd rather have it there too.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJw3THUMcvC4SDtJQQfkE1
